### PR TITLE
v2: human-decision ingestion, dependency graph & dashboard UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,17 @@ LOCKSTEP_WEB_URL=
 # ---- Outbound (urgent pings) ----
 SLACK_BOT_TOKEN=
 
+# ---- v2 human-decision ingestion (packages/ingest worker) ----
+# Composio connector key — used by core for OAuth initiation and by the worker for message fetch.
+COMPOSIO_API_KEY=
+# Shared service token the ingest worker presents to core's /ingest/* worker endpoints.
+LOCKSTEP_INGEST_TOKEN=
+# Anthropic key for the distillation funnel (worker only). Haiku recall → Sonnet extract → Opus recheck.
+ANTHROPIC_API_KEY=
+# Optional self-host connector backend (data-residency swap behind SourceConnector): lockstep-ingest sweep --nango
+NANGO_SECRET_KEY=
+NANGO_HOST=https://api.nango.dev
+
 # ---- Dev-mode login bypass ----
 # Enables /auth/dev-login (no GitHub App needed). Never honored when NODE_ENV=production.
 LOCKSTEP_DEV_LOGIN=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,28 @@ jobs:
       matrix:
         node-version: [20, 22]
 
+    # DB-touching tests in @lockstep/core parse DATABASE_URL at boot (env.ts) and run against a
+    # real Postgres (Drizzle migrations + RLS). Provide both here; LOCKSTEP_INGEST_TOKEN lets the
+    # ingest worker-endpoint tests exercise their authenticated paths.
+    env:
+      DATABASE_URL: postgres://lockstep:lockstep@localhost:5432/lockstep
+      LOCKSTEP_INGEST_TOKEN: test-ingest-secret
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: lockstep
+          POSTGRES_PASSWORD: lockstep
+          POSTGRES_DB: lockstep
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U lockstep -d lockstep"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -33,6 +55,9 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: Run migrations
+        run: npm run db:migrate
 
       - name: Test
         run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ npm-debug.log*
 
 # local Claude Code config
 .claude/
+
+# local knowledge-graph analysis output (graphify)
+graphify-out/
+
+# Marketing website lives in its own repo (github: lockstep-website) — never commit it here.
+packages/website/

--- a/README.md
+++ b/README.md
@@ -18,15 +18,6 @@
   <a href="./DEPLOY.md"><b>Deploy</b></a>
 </p>
 
-<p align="center">
-  <img src="docs/assets/new-stack.png" alt="The new stack for software development: code stays in GitHub, agents read and write it, and the decision &amp; coordination layer (Lockstep) sits on top." width="860">
-</p>
-
-<!--
-  Once recorded, the 25s two-developer demo GIF (storyboard in docs/DEMO.md) can join or replace the
-  diagram above as the lead visual: <img src="docs/assets/demo.gif" alt="Lockstep in action" width="820">
--->
-
 ---
 
 When two developers point AI coding agents at the same system, the agents have no idea what each other just did:
@@ -38,6 +29,15 @@ When two developers point AI coding agents at the same system, the agents have n
 The thing that actually steers a codebase isn't the code — it's the **decisions**. Today those decisions live in people's heads, scattered Slack threads, and stale docs that no agent ever reads.
 
 **Lockstep is GitHub for the decisions your AI agents make.** Every decision, change, and question is captured once and replayed to every agent that needs it — ranked by blast radius, so the important ones surface and the noise doesn't.
+
+<p align="center">
+  <img src="docs/assets/new-stack.png" alt="The new stack for software development: code stays in GitHub, agents read and write it, and the decision &amp; coordination layer (Lockstep) sits on top." width="860">
+</p>
+
+<!--
+  Once recorded, the 25s two-developer demo GIF (storyboard in docs/DEMO.md) can become the lead visual,
+  moved above the problem statement: <img src="docs/assets/demo.gif" alt="Lockstep in action" width="820">
+-->
 
 ```bash
 npm i -g lockstep-cli
@@ -94,6 +94,8 @@ npm i -g lockstep-cli
 lockstep login --api https://lockstep-production.up.railway.app   # opens GitHub to authorize
 ```
 
+> The hosted URLs above are a **best-effort demo instance**, not a production service — great for trying Lockstep, but self-host (below) for anything real.
+
 <details>
 <summary><b>Prefer to self-host?</b> — one Docker command</summary>
 
@@ -142,7 +144,7 @@ Open Claude Code (or any MCP agent) in the repo. On session start, the agent rec
 
 ## Agents & integration
 
-Works with **any MCP-compatible agent**. Auto-capture hooks ship for **Claude Code** today; Codex and Gemini adapters are on the roadmap. The 13-tool MCP server runs per-session on the developer's machine and is identical across vendors — new integrations are a single adapter file.
+Works with **any MCP-compatible agent**. Auto-capture hooks ship for **Claude Code** today; Codex and Gemini adapters are on the roadmap. The 14-tool MCP server runs per-session on the developer's machine and is identical across vendors — new integrations are a single adapter file.
 
 ## CLI Commands
 
@@ -166,7 +168,7 @@ actions/pr-check # GitHub Action — PR-time reconciliation gate
 ## Learn more
 
 - [Deploy](./DEPLOY.md) · [Contributing](./CONTRIBUTING.md) · [Security](./SECURITY.md) · [Changelog](./CHANGELOG.md)
-- Architecture: 26-table schema with row-level security, append-only CAS-versioned decision ledger, vendor-neutral MCP adapters, Zod validation on every boundary, TypeScript strict throughout. Self-host with `docker compose` or deploy to Railway.
+- Built on row-level-security Postgres, an append-only CAS-versioned decision ledger, and vendor-neutral MCP adapters. Self-host with `docker compose` or deploy to Railway.
 
 ## License
 

--- a/docs/V2_INGESTION_PLAN.md
+++ b/docs/V2_INGESTION_PLAN.md
@@ -1,0 +1,222 @@
+# Lockstep v2 — Human-Decision Ingestion Plan
+
+> Expand the *source* side of "GitHub for decisions": harvest decisions humans make in
+> Slack / Jira / Notion / Confluence **before** any code is written, distill them into the
+> **same** decision ledger, and replay them to agents — while making humans real users.
+>
+> Seven locked product decisions (see `memory/lockstep-v2-ingestion.md`):
+> distilled decisions (not raw artifacts) · read-in only · scheduled sweeps · draft-then-confirm ·
+> org-graph beyond code surfaces · one-decision-many-provenances · **allowlisted sources only**.
+> Connector layer: **Composio** (SaaS, MCP-native, free tier). First slice: **Slack → review → briefing**.
+
+---
+
+## Part A — The distillation engine (the make-or-break)
+
+The hard question isn't "how do we connect Slack" — Composio does that. It's **"given a firehose of
+messages, how do we reliably pull out the handful that are real, durable decisions, and nothing else."**
+Everything downstream (binding, PR gates) trusts this. We treat it as a **recall-first funnel that
+narrows to precision**, with a human as the final precision gate.
+
+### A.1 The decision rubric — what actually qualifies
+
+A message becomes a *decision* only if it passes four tests. This rubric is the literal grading
+instruction we give the extraction model, and the definition humans see in the review queue.
+
+| Test | Question | Fails → it's a… |
+|------|----------|-----------------|
+| **Durability** | Does it constrain *future* work beyond the task at hand? | one-off action → **change/task**, not a decision |
+| **Agreement** | Was it actually *concluded*, or still being debated? | still open → **question**, or discard |
+| **Agency** | Was it a real *choice among alternatives* (vs a statement of fact)? | fact/status update → discard |
+| **Specificity** | Can it be restated as one imperative rule? | vague sentiment → discard |
+
+This mirrors the v1 change-vs-decision split — now applied to human text instead of git diffs.
+A decision is a **durable rule or architectural choice**; everything else is noise we deliberately drop.
+
+### A.2 The funnel (cheap → expensive → human)
+
+```
+Stage 0  SEGMENT     threads/pages since watermark → conversation units (a Slack thread = 1 unit)
+Stage 1  RECALL      cheap filter: "could this unit contain a decision?"   (Haiku / keyword+embedding)
+Stage 2  EXTRACT     structured LLM call: rubric + provenance              (Sonnet, forced JSON schema)
+Stage 3  SCOPE       map to canonical surface OR org-graph node → impact
+Stage 4  DEDUP       vs already-ingested (idempotency) + vs existing decisions (semantic)
+Stage 5  GATE        confidence + finality → propose / raise-question / discard
+Stage 6  FILE        proposed decision, rich provenance, ranked into review queue
+Stage 7  HUMAN       confirm / edit / merge / reject  → only now can it bind
+```
+
+Why a funnel: running the expensive extraction model on every Slack message is cost-prohibitive and
+noisy. Stage 1 is tuned for **recall** (better to pass junk forward than miss a decision); Stages 2–5
+add **precision**; Stage 7 is the **guaranteed** precision gate — no extracted decision ever binds
+without a human, per the locked product decision.
+
+### A.3 Stage 1 — cheap candidate filter (recall)
+
+Goal: drop the ~95% of threads that obviously contain no decision, cheaply.
+- **Signals:** decision-language markers ("let's go with", "we decided", "final call", "agreed",
+  "going forward", "from now on", "the plan is", "approved", "RFC/ADR"), ✅/👍 reactions on a proposal,
+  thread resolved/📌 pinned, Jira status→Done with a comment, Notion page tagged decision/ADR.
+- **Mechanism:** keyword pre-filter → embedding similarity to a "decision prototype" set → Haiku 4.5
+  binary "maybe-decision?" on the survivors. Cheap, high-recall. Tune the threshold on the eval set (A.7).
+
+### A.4 Stage 2 — structured extraction (precision core)
+
+One forced-JSON Claude call (Sonnet 4.6; escalate low-confidence to Opus 4.8) per candidate unit,
+grading against the A.1 rubric and returning:
+
+```jsonc
+{
+  "is_decision": true,
+  "decision_type": "rule" | "architecture",
+  "finality": "agreed" | "proposed" | "reversed" | "superseded",  // only "agreed" is binding-eligible
+  "rule_text": "Auth tokens are JWT with 15-minute expiry.",       // durable, imperative
+  "rationale": "Chosen over sessions to stay stateless across services.",
+  "alternatives_considered": ["server-side sessions", "opaque tokens"],
+  "decided_by": ["@alice", "@bob"],           // who assented
+  "decided_at": "2026-06-30T14:12:00Z",
+  "scope_hint": "authentication",             // free-text area, resolved in Stage 3
+  "surface_candidates": ["POST /auth/session"],// code surfaces referenced, if any
+  "confidence": 0.86,
+  "evidence": [                               // exact quotes — provenance + what the reviewer reads
+    { "externalId": "C123/p1699", "quote": "ok let's lock it: JWT, 15 min. shipping it." }
+  ]
+}
+```
+
+`evidence` is mandatory and verbatim — it is both the provenance trail and what a human reviews, so a
+hallucinated rule has a quote a reviewer can immediately falsify. System prompt is **prompt-cached**
+(rubric + schema are constant) to cut cost.
+
+### A.5 Stage 3 — scope resolution & impact
+
+- Try to canonicalize each `surface_candidate` with the existing grammar
+  (`http:METHOD /path`, `proto:pkg.Service/Rpc`, `gql:Root.field` — reuse `capture/surface.ts` logic).
+- **Surface matches the dependency graph** → real impact via `impactForScopeTx` (v1 path, unchanged).
+- **No surface** → resolve `scope_hint` to an **org-graph node** (team/project/topic) and assign a
+  coarse impact from that node's fan-out. Until the org-graph ships (Phase 3), non-code decisions land
+  `scopeKind:"topic"`, impact 0 (own-area) — recorded, low-ranked, honestly flagged "unscoped".
+
+### A.6 Stages 4–6 — dedup, gate, file
+
+- **Idempotency:** every unit hashes to `(connectionId, externalId, contentHash)` in `ingestArtifacts`;
+  a re-seen thread is never re-distilled. This is the watermark's correctness backstop.
+- **Semantic dedup (Phase 2+):** embedding-match `rule_text` against existing decisions in the same
+  scope. Match → **attach as another provenance** (the "one decision, many provenances" goal) rather
+  than mint a duplicate. Contradiction with a *binding* decision → file as a **proposed supersession**,
+  surfacing both to the reviewer. Ambiguous → flag for human merge in the queue (the accepted fallback).
+- **Gate:** `is_decision:false` or `confidence < floor` → discard (logged for tuning, not shown).
+  `finality != "agreed"` → file as a **Question** ("Did the team decide X?"), never a rule.
+  Otherwise → **proposed decision**. Confidence ranks the queue and pre-selects the reviewer's default
+  action; it never lets anything skip the human.
+- **File:** `fileProposedDecision()` writes `status:"proposed"`, `origin:"ingested"`, full provenance.
+
+### A.7 Making it *good* over time (the eval loop)
+
+Extraction quality is a tuning problem, so we build for it from day one:
+- **Golden set:** ~50 hand-labeled real threads (decision / not / which rule) → measured precision &
+  recall per stage on every prompt change.
+- **Human feedback = labels:** every reject/edit/merge in the review queue is written back as an eval
+  example. Reject rate and edit-distance are the north-star quality metrics.
+- **Model tiering:** Haiku (Stage 1) → Sonnet (Stage 2) → Opus only on low-confidence re-checks.
+  Batch + prompt caching keep cost roughly linear in *candidate* volume, not *message* volume.
+
+---
+
+## Part B — Architecture & new components
+
+Nothing in v1 polls or runs background work; all fan-out is in-band in a request transaction. v2 adds
+one new long-running process and keeps core as the **single DB owner** (RLS intact). The worker never
+touches Postgres directly — it talks to core over HTTP with a service token, matching the existing
+"packages communicate over HTTP boundaries" design.
+
+```
+                       ┌───────────────── packages/ingest  (NEW, long-running) ─────────────────┐
+   Composio cloud  ◀──▶ │  scheduler → SourceConnector(Composio) → distillation funnel (Part A)  │
+   Slack/Jira/…         │            (Anthropic SDK: Haiku/Sonnet/Opus, prompt-cached)           │
+                        └───────────────────────────────┬───────────────────────────────────────┘
+                                     service-token HTTP  │  GET /ingest/work · POST /ingest/proposed-decisions · POST /ingest/watermark
+                                                         ▼
+   packages/core (Fastify + PG, RLS)  ──  new routes/ingest.ts + ledgerService.fileProposedDecision/confirm/reject
+                                                         │
+   packages/web (Next.js)  ──  /review-queue · /connections (Composio OAuth + allowlist) · /search
+```
+
+### B.1 New package: `packages/ingest` (`@lockstep/ingest`)
+- `src/scheduler.ts` — per-connection sweep loop (default 15 min); reads due work from `GET /ingest/work`.
+- `src/connectors/SourceConnector.ts` — **interface** (`listUpdatedSince`, `fetchUnit`, `resolveMembers`).
+  This is the seam that lets a self-hosted **Nango** backend replace Composio later (the accepted mitigation).
+- `src/connectors/ComposioConnector.ts` — Composio SDK/MCP impl for Slack (Jira/Notion/Confluence in Phase 2).
+- `src/connectors/StubConnector.ts` — returns canned threads; powers deterministic e2e tests with no network.
+- `src/distill/{recall.ts, extract.ts, scope.ts, dedup.ts, gate.ts}` — the Part-A funnel.
+- `src/client.ts` — thin authed HTTP client to core (`/ingest/*`).
+- Deployed as a second Railway service; same image, different entrypoint.
+
+### B.2 Core changes (`packages/core`)
+- **Schema** (`src/db/schema.ts` + new migration `drizzle/0002_ingestion.sql`):
+  - `decisions.status`: add `proposed`, `rejected`. `decisions.origin`: new enum `agent | ingested` (default `agent`).
+  - `decisionVersions.provenance` (JSONB, already exists) carries `{source, connectionId, externalId, url, evidence[], extractorModel, confidence, decidedBy, decidedAt}` — no shape migration needed.
+  - `sourceConnections` — `(orgId, projectId, tool, composioConnectionId, status, createdBy)`.
+  - `ingestAllowlist` — `(orgId, projectId, connectionId, sourceKind[channel|project|space], sourceRef, sourceName, enabled)` — the opt-in; **nothing is swept unless listed here**.
+  - `ingestWatermarks` — `(orgId, connectionId, sourceRef, cursor, updatedAt)`.
+  - `ingestArtifacts` — `(orgId, connectionId, externalId, contentHash, status[distilled|discarded|proposed], confidence, decisionId?)` — idempotency + tuning audit. Stores evidence quotes only, not full raw content.
+  - Phase 3 org-graph: `graphNodes (kind[team|project|doc|person|surface], ref, label, source[derived|manual])` + `graphEdges (fromId, toId, kind, weight)`.
+- **Service** (`src/ledger/ledger-service.ts`): `fileProposedDecision()` (origin=ingested, status=proposed, bypasses binding), `confirmDecision()` (proposed → runs the normal impact/binding path), `rejectDecision()`, `mergeDecision(intoId)` (attach provenance / supersede). `listDecisions` gains a `status`/`origin` filter.
+- **Routes** (`src/api/routes/ingest.ts` + additions to `ledger.ts`/`dashboard.ts`):
+  - Worker (service-token): `GET /ingest/work`, `POST /ingest/proposed-decisions`, `POST /ingest/watermark`.
+  - Admin: `POST/GET /orgs/:o/connections`, `POST/GET /orgs/:o/projects/:p/allowlist`.
+  - Review: `GET …/decisions?status=proposed`, `POST /decisions/:id/confirm|reject|merge`.
+  - Search: `GET …/decisions/search?q=&scopeKind=&status=&from=&to=`.
+- **Auth:** a new **service principal** + token scope for the worker (write proposed decisions across a
+  tenant); reuses the existing token/RLS machinery.
+
+### B.3 Web changes (`packages/web`)
+- `app/project/[orgId]/[projectId]/review-queue/page.tsx` — proposed-decision cards: rule text, the
+  clickable Slack/Jira/Notion provenance, the verbatim evidence quote, confidence, suggested
+  scope/impact, and **Confirm / Edit / Reject / Merge**. Nav badge shows the queue count. (Phase 1)
+- `app/project/[orgId]/[projectId]/connections/page.tsx` — Connect Slack via Composio OAuth; pick the
+  allowlisted channels. (Phase 1)
+- `app/project/[orgId]/[projectId]/search/page.tsx` — "what did we decide about X?" over the ledger. (Phase 2)
+- Blast-radius notifications for humans (bell/email) — reuses audit + graph. (Phase 3)
+- Follows the existing custom-CSS design system (`globals.css` tokens, `StatusPill`, `PageHead`, `EmptyState`).
+
+### B.4 What does NOT change
+- The **agent path is untouched**: once a proposed decision is confirmed, it's an ordinary ledger
+  decision — it flows into the existing session-start briefing and PR gate with no agent-side change.
+  The skill (`adapters/templates.ts`) needs only a one-line note that a briefing item may cite an
+  external source. No new MCP tools required for the core loop.
+
+---
+
+## Part C — Phased delivery
+
+| Phase | Goal | Ships |
+|-------|------|-------|
+| **0 — Foundation** | Rails for everything, no user-visible feature | schema migration (proposed/origin/source tables), `packages/ingest` skeleton, `SourceConnector` interface + `StubConnector`, service-token auth, `/ingest/*` routes, `fileProposedDecision/confirm/reject`. E2e: Stub → proposed → confirm → appears in a briefing. |
+| **1 — Slack vertical slice** ⭐ | **The demo.** One channel end-to-end | `ComposioConnector` (Slack), connect+allowlist UI, the full Part-A funnel for Slack, review-queue UI, confirmed decision → existing briefing. **Single-source, idempotency-only dedup.** |
+| **2 — Breadth + memory** | More sources, humans can search | Jira + Notion + Confluence connectors (same interface, per-source segmentation/prompts), decision **search** page, intra-tool semantic dedup + supersession detection. |
+| **3 — Org graph + fusion** | Impact for non-code, one-decision-many-provenances | `graphNodes/graphEdges` auto-derived from connectors + human correction UI, impact for non-surface decisions, cross-tool identity resolution, blast-radius notifications. |
+| **4 — Hardening / enterprise** | Trust, cost, coverage | Nango self-host swap behind `SourceConnector`, cost controls + eval harness in CI, retention/redaction policy, ClickUp / Google Docs. |
+
+Slice 1 is the proof: it exercises sweep → distill → propose → confirm → replay on the hardest,
+highest-value source, and is independently demoable.
+
+---
+
+## Part D — Key risks & how the design contains them
+
+| Risk | Containment |
+|------|-------------|
+| **Bad extraction binds a false rule** | Universal draft-then-confirm (Stage 7); nothing binds without a human. Mandatory verbatim `evidence` makes review fast and falsifiable. |
+| **LLM cost on Slack firehose** | Recall funnel (cheap Stage 1), model tiering, batching, prompt caching. Cost scales with *candidates*, not messages. |
+| **Reads sensitive content** | Allowlist-only — nothing swept unless a channel/project/space is opted in. Store evidence quotes, not full raw content. |
+| **Composio data residency** | `SourceConnector` seam → Nango self-host swap in Phase 4; documented as an accepted v1 trade-off. |
+| **Cross-tool dedup is hard** | Deferred past slice 1; idempotency (Stage 4a) ships first, semantic fusion is Phase 2–3, ambiguous cases fall to human merge. |
+| **Org-graph is a big lift** | Non-code decisions honestly land impact-0/`topic` until Phase 3; not blocking the slice. |
+
+## Part E — Testing
+- Local PG at `127.0.0.1:5433` (existing test setup). Migrations hand-authored against the journal.
+- **Deterministic e2e** via `StubConnector`: canned threads → assert proposed decisions land, confirm
+  → assert briefing contains them. No network, no Composio in CI.
+- **Extraction eval:** golden set of ~50 labeled threads; precision/recall gate on prompt changes.
+- Live Composio smoke test kept out of CI (interactive auth), run manually against a sandbox workspace.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "lockstep",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
         "actions/*"
@@ -24,7 +25,88 @@
     },
     "actions/pr-check": {
       "name": "@lockstep/pr-check",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.109.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.109.0.tgz",
+      "integrity": "sha512-y7P4eLyW5uNut4fXpOUEHqhJwx7dnxrWAfCQE4Lcgm0hSFQuIeHa7CWEKE5dFolEjQJE/RFKkppjri05r2OK/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@composio/client": {
+      "version": "0.1.0-alpha.74",
+      "resolved": "https://registry.npmjs.org/@composio/client/-/client-0.1.0-alpha.74.tgz",
+      "integrity": "sha512-/EHJsFxCpWfRxNvXURRrGVZfJSltSpN4Gkd9M9Cl5gPOirG+NpbXf2B8d4B72H87m7cnOguMKjOH42ogQ84/Ww==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/@composio/core": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@composio/core/-/core-0.13.1.tgz",
+      "integrity": "sha512-bC64PJG3RBeuezihfZV/9qJMd1LyzUEFN1tVHTWh32n/muUMr5I33nN6Mezhtkl4+ffBJ8IZ/mNt9tEQKFB/sw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@composio/client": "0.1.0-alpha.74",
+        "@composio/json-schema-to-zod": "0.2.0",
+        "@types/json-schema": "^7.0.15",
+        "openai": "^6.42.0",
+        "picocolors": "^1.1.1",
+        "pusher-js": "^8.5.0",
+        "semver": "^7.8.4",
+        "zod-to-json-schema": "^3.25.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/@composio/json-schema-to-zod": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@composio/json-schema-to-zod/-/json-schema-to-zod-0.2.0.tgz",
+      "integrity": "sha512-P7ym7+1NCN2cDVlSOGTINY6KjZ/d162uc+0LChYcy3d5RAAacgHiGU7ZJF+5pUJHbIivsfAC/4PdjVdsfmHdeA==",
+      "license": "ISC",
+      "optional": true,
+      "peerDependencies": {
+        "zod": ">=3.25.76 <5"
+      }
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
@@ -1215,8 +1297,51 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@lockstep/core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@lockstep/ingest": {
+      "resolved": "packages/ingest",
       "link": true
     },
     "node_modules/@lockstep/pr-check": {
@@ -1225,6 +1350,10 @@
     },
     "node_modules/@lockstep/web": {
       "resolved": "packages/web",
+      "link": true
+    },
+    "node_modules/@lockstep/website": {
+      "resolved": "packages/website",
       "link": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -1417,10 +1546,54 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -1457,7 +1630,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1806,6 +1979,47 @@
         }
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1813,6 +2027,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
+      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.4",
+        "caniuse-lite": "^1.0.30001799",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
       }
     },
     "node_modules/avvio": {
@@ -1866,6 +2117,32 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -1913,6 +2190,53 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/buffer": {
@@ -1996,10 +2320,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001797",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
-      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2016,6 +2350,44 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -2028,6 +2400,25 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -2102,6 +2493,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -2189,6 +2593,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/drizzle-kit": {
       "version": "0.31.10",
       "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
@@ -2224,6 +2642,13 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.383",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.383.tgz",
+      "integrity": "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -2365,6 +2790,16 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -2720,6 +3155,36 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2766,6 +3231,12 @@
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -2856,6 +3327,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2936,6 +3420,47 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {
@@ -3207,6 +3732,35 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3230,6 +3784,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -3241,6 +3805,16 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.3",
@@ -3281,6 +3855,19 @@
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -3375,6 +3962,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3407,6 +4014,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.460.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.460.0.tgz",
+      "integrity": "sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3435,6 +4051,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime-db": {
@@ -3508,11 +4161,38 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -3625,6 +4305,26 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3632,6 +4332,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -3674,6 +4384,37 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -3754,6 +4495,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -3781,6 +4529,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pino": {
@@ -3820,6 +4578,16 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -3856,6 +4624,140 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/postgres": {
       "version": "3.4.9",
@@ -3983,6 +4885,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/pusher-js": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.5.0.tgz",
+      "integrity": "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -3997,6 +4909,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
@@ -4069,6 +5002,16 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -4082,6 +5025,32 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/real-require": {
@@ -4100,6 +5069,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -4151,6 +5142,30 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -4237,9 +5252,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4493,6 +5508,16 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4553,6 +5578,119 @@
         }
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
+      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -4581,6 +5719,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/thread-stream": {
@@ -4618,6 +5779,19 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toad-cache": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.1.tgz",
@@ -4636,6 +5810,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -4648,6 +5828,13 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -5120,6 +6307,13 @@
         "node": "*"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense",
+      "optional": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5194,6 +6388,37 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5208,8 +6433,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -5285,7 +6510,7 @@
     "packages/cli": {
       "name": "lockstep-cli",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "zod": "^3.23.8"
@@ -5308,6 +6533,7 @@
     "packages/core": {
       "name": "@lockstep/core",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
         "fastify": "^5.1.0",
@@ -5446,9 +6672,32 @@
         }
       }
     },
+    "packages/ingest": {
+      "name": "@lockstep/ingest",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "latest"
+      },
+      "bin": {
+        "lockstep-ingest": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.9.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@composio/core": "latest"
+      }
+    },
     "packages/web": {
       "name": "@lockstep/web",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "next": "^14.2.35",
         "react": "^18.3.1",
@@ -5459,6 +6708,58 @@
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
         "typescript": "^5.6.3"
+      }
+    },
+    "packages/website": {
+      "name": "@lockstep/website",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "framer-motion": "^11.11.0",
+        "lucide-react": "^0.460.0",
+        "next": "^14.2.35",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "tailwind-merge": "^2.5.4"
+      },
+      "devDependencies": {
+        "@types/node": "^22.9.0",
+        "@types/react": "^18.3.11",
+        "@types/react-dom": "^18.3.0",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.49",
+        "tailwindcss": "^3.4.15",
+        "typescript": "^5.6.3"
+      }
+    },
+    "packages/website/node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     }
   }

--- a/packages/cli/src/adapters/templates.ts
+++ b/packages/cli/src/adapters/templates.ts
@@ -30,7 +30,7 @@ This project uses Lockstep to coordinate multiple developers' coding agents on t
 
 ## On session start
 - Call \`inbox\` to see what changed, what's newly binding, and what's delegated to you.
-- Call \`decisions\` to load the binding rules for the areas you'll touch.
+- Call \`decisions\` to load the binding rules for the areas you'll touch. A rule may cite an external source (e.g. a Slack thread) — it was distilled from a human decision and confirmed by a teammate; treat it exactly like any other binding decision.
 - If you see open questions or tasks in the inbox, tell the user about them.
 
 ## Before coding a shared/contract surface

--- a/packages/core/drizzle/0002_ingestion.sql
+++ b/packages/core/drizzle/0002_ingestion.sql
@@ -1,0 +1,53 @@
+-- v2 human-decision ingestion: proposed/rejected decision lifecycle, origin, and the ingest tables.
+-- Hand-authored (db:generate is broken in this repo; see memory/lockstep-mvp-defects). Idempotent.
+
+ALTER TABLE "decisions" ADD COLUMN IF NOT EXISTS "origin" text DEFAULT 'agent' NOT NULL;--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "source_connections" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL,
+  "project_id" uuid NOT NULL,
+  "tool" text NOT NULL,
+  "entity" text NOT NULL,
+  "connected_account_id" text,
+  "status" text DEFAULT 'pending' NOT NULL,
+  "created_by" uuid,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_source_conn_project" ON "source_connections" ("project_id","tool");--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "ingest_allowlist" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL,
+  "project_id" uuid NOT NULL,
+  "connection_id" uuid NOT NULL,
+  "source_kind" text NOT NULL,
+  "source_ref" text NOT NULL,
+  "source_name" text,
+  "enabled" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_allowlist_conn_source" ON "ingest_allowlist" ("connection_id","source_ref");--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "ingest_watermarks" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL,
+  "connection_id" uuid NOT NULL,
+  "source_ref" text NOT NULL,
+  "cursor" text,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_watermark_conn_source" ON "ingest_watermarks" ("connection_id","source_ref");--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "ingest_artifacts" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL,
+  "connection_id" uuid NOT NULL,
+  "external_id" text NOT NULL,
+  "content_hash" text NOT NULL,
+  "status" text NOT NULL,
+  "confidence" integer,
+  "decision_id" uuid,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_artifact_conn_ext_hash" ON "ingest_artifacts" ("connection_id","external_id","content_hash");

--- a/packages/core/drizzle/0003_fusion_graph.sql
+++ b/packages/core/drizzle/0003_fusion_graph.sql
@@ -1,0 +1,40 @@
+-- v2 Phase 2/3: cross-tool provenance fusion + org graph. Hand-authored, idempotent.
+
+CREATE TABLE IF NOT EXISTS "decision_provenances" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL,
+  "decision_id" uuid NOT NULL,
+  "source" text NOT NULL,
+  "external_id" text,
+  "url" text,
+  "evidence" jsonb,
+  "confidence" integer,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_provenance_decision" ON "decision_provenances" ("decision_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_provenance_decision_source" ON "decision_provenances" ("decision_id","source","external_id");--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "graph_nodes" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL,
+  "project_id" uuid NOT NULL,
+  "kind" text NOT NULL,
+  "ref" text NOT NULL,
+  "label" text,
+  "source" text DEFAULT 'derived' NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_graph_node" ON "graph_nodes" ("project_id","kind","ref");--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "graph_edges" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL,
+  "project_id" uuid NOT NULL,
+  "from_id" uuid NOT NULL,
+  "to_id" uuid NOT NULL,
+  "kind" text DEFAULT 'relates' NOT NULL,
+  "weight" integer DEFAULT 1 NOT NULL,
+  "source" text DEFAULT 'derived' NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_graph_edge" ON "graph_edges" ("project_id","from_id","to_id","kind");

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -15,6 +15,20 @@
       "when": 1790000000000,
       "tag": "0001_decision_taxonomy_impact",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1793000000000,
+      "tag": "0002_ingestion",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1793500000000,
+      "tag": "0003_fusion_graph",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx src/db/migrate.ts",
     "db:reset": "tsx src/db/reset.ts",
-    "test": "find src -name '*.test.ts' | xargs node --import tsx --test --test-force-exit"
+    "test": "find src -name '*.test.ts' | xargs node --import tsx --test --test-force-exit",
+    "coverage": "sh -c 'export LOCKSTEP_INGEST_TOKEN=test-ingest-secret; find src -name \"*.test.ts\" | xargs node --import tsx --test --test-force-exit --experimental-test-coverage --test-coverage-include=\"src/ingest/ingest-service.ts\" --test-coverage-include=\"src/graph/graph-service.ts\" --test-coverage-include=\"src/ledger/ledger-service.ts\" --test-coverage-include=\"src/api/routes/ingest.ts\" --test-coverage-exclude=\"**/*.test.ts\"'"
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",

--- a/packages/core/sql/0001_rls.sql
+++ b/packages/core/sql/0001_rls.sql
@@ -36,7 +36,9 @@ DECLARE child_tables text[] := ARRAY[
   'ownership_snapshots','ownership_rules','ownership_rule_owners',
   'decisions','decision_versions','decision_required_reviewers','decision_approvals',
   'contracts','dependency_edges','questions','answers','change_feed_entries',
-  'tasks','inboxes','inbox_items','sessions','audit_events'
+  'tasks','inboxes','inbox_items','sessions','audit_events',
+  'source_connections','ingest_allowlist','ingest_watermarks','ingest_artifacts',
+  'decision_provenances','graph_nodes','graph_edges'
 ];
 DECLARE system_tables text[] := ARRAY['principals','access_tokens','github_credentials'];
 BEGIN

--- a/packages/core/src/api/app.ts
+++ b/packages/core/src/api/app.ts
@@ -5,6 +5,7 @@ import { orgRoutes } from "./routes/orgs.js";
 import { sessionRoutes } from "./routes/sessions.js";
 import { ledgerRoutes } from "./routes/ledger.js";
 import { dashboardRoutes } from "./routes/dashboard.js";
+import { ingestRoutes } from "./routes/ingest.js";
 import { queryClient } from "../db/client.js";
 import { env } from "../env.js";
 
@@ -29,6 +30,7 @@ export function buildApp(): FastifyInstance {
   void app.register(sessionRoutes);
   void app.register(ledgerRoutes);
   void app.register(dashboardRoutes);
+  void app.register(ingestRoutes);
 
   return app;
 }

--- a/packages/core/src/api/routes/ingest.api.test.ts
+++ b/packages/core/src/api/routes/ingest.api.test.ts
@@ -1,0 +1,143 @@
+/**
+ * HTTP-level coverage of the ingest routes via Fastify's inject() — no socket. Exercises principal
+ * auth + org membership, the admin/review/graph/search endpoints, and the service-token worker
+ * endpoints (worker-success assertions run only when LOCKSTEP_INGEST_TOKEN is set — the `coverage`
+ * script sets it; plain `test` covers the 401 branch).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../app.js";
+import { env } from "../../env.js";
+import { withSystem } from "../../db/rls.js";
+import { orgs, principals, members, projects } from "../../db/schema.js";
+import { issueTokenTx } from "../../auth/tokens.js";
+
+function one<T>(rows: T[]): T {
+  const r = rows[0];
+  if (!r) throw new Error("expected a row");
+  return r;
+}
+let seq = Date.now() + 950_000_000;
+const uid = (): number => ++seq;
+
+async function setup() {
+  const n = uid();
+  return withSystem(async (tx) => {
+    const org = one(await tx.insert(orgs).values({ name: `ApiCo-${n}` }).returning());
+    const p = one(await tx.insert(principals).values({ githubUserId: uid(), githubLogin: `m-${n}` }).returning());
+    await tx.insert(members).values({ orgId: org.id, principalId: p.id, githubUserId: p.githubUserId, githubLogin: `m-${n}` });
+    const proj = one(await tx.insert(projects).values({ orgId: org.id, name: "api" }).returning());
+    const token = await issueTokenTx(tx, p.id);
+    // an outsider principal — has a token but is NOT a member of the org
+    const outsider = one(await tx.insert(principals).values({ githubUserId: uid(), githubLogin: `o-${n}` }).returning());
+    const outsiderToken = await issueTokenTx(tx, outsider.id);
+    return { orgId: org.id, projectId: proj.id, token, outsiderToken };
+  });
+}
+
+let app: FastifyInstance;
+const auth = (t: string) => ({ authorization: `Bearer ${t}` });
+
+test("ingest API: full admin → worker → review → graph → search flow", async () => {
+  app = buildApp();
+  const s = await setup();
+  const base = `/orgs/${s.orgId}/projects/${s.projectId}`;
+
+  // membership gate
+  const forbidden = await app.inject({ method: "GET", url: `${base}/connections`, headers: auth(s.outsiderToken) });
+  assert.equal(forbidden.statusCode, 403, "non-member is rejected");
+  const unauth = await app.inject({ method: "GET", url: `${base}/connections` });
+  assert.equal(unauth.statusCode, 401, "no token is unauthorized");
+
+  // create + list connection
+  const created = await app.inject({ method: "POST", url: `${base}/connections`, headers: auth(s.token), payload: { tool: "slack" } });
+  assert.equal(created.statusCode, 200);
+  const connectionId = created.json().connectionId as string;
+  const conns = await app.inject({ method: "GET", url: `${base}/connections`, headers: auth(s.token) });
+  assert.ok((conns.json().connections as unknown[]).length >= 1);
+
+  // allowlist
+  const allow = await app.inject({ method: "POST", url: `${base}/allowlist`, headers: auth(s.token), payload: { connectionId, sourceRef: "C1", sourceName: "#eng" } });
+  assert.equal(allow.statusCode, 200);
+  const allowMissing = await app.inject({ method: "POST", url: `${base}/allowlist`, headers: auth(s.token), payload: { connectionId } });
+  assert.equal(allowMissing.statusCode, 400, "sourceRef required");
+
+  // worker endpoints (service token)
+  const noToken = await app.inject({ method: "GET", url: "/ingest/work" });
+  assert.equal(noToken.statusCode, 401, "worker endpoint needs the ingest token");
+
+  const ingestToken = env.LOCKSTEP_INGEST_TOKEN;
+  if (ingestToken) {
+    const wtok = { "x-lockstep-ingest-token": ingestToken };
+    await app.inject({ method: "POST", url: `/ingest/connections/${connectionId}/finalize`, headers: wtok, payload: { connectedAccountId: "acct-1" } });
+    const work = await app.inject({ method: "GET", url: "/ingest/work", headers: wtok });
+    assert.equal(work.statusCode, 200);
+
+    const filed = await app.inject({
+      method: "POST",
+      url: "/ingest/proposed-decisions",
+      headers: wtok,
+      payload: {
+        items: [
+          {
+            orgId: s.orgId,
+            projectId: s.projectId,
+            scopeKind: "topic",
+            scopeRef: "topic:api-test",
+            ruleText: "API tests run via inject.",
+            provenance: { source: "slack", evidence: [{ externalId: "z", quote: "use inject" }], decidedBy: ["@a"] },
+            connectionId,
+            externalId: "z",
+            contentHash: "hz",
+            confidence: 80,
+          },
+        ],
+      },
+    });
+    assert.equal(filed.statusCode, 200);
+    assert.equal(filed.json().filed, 1);
+
+    await app.inject({ method: "POST", url: "/ingest/watermark", headers: wtok, payload: { orgId: s.orgId, connectionId, sourceRef: "C1", cursor: "5.0" } });
+
+    // review queue → confirm
+    const proposed = await app.inject({ method: "GET", url: `${base}/proposed`, headers: auth(s.token) });
+    const decision = (proposed.json().decisions as Array<{ id: string; scopeRef: string }>).find((d) => d.scopeRef === "topic:api-test");
+    assert.ok(decision, "proposed decision shows in the review queue");
+    const confirmed = await app.inject({ method: "POST", url: `/orgs/${s.orgId}/decisions/${decision!.id}/confirm`, headers: auth(s.token), payload: {} });
+    assert.equal(confirmed.statusCode, 200);
+  }
+
+  // graph derive + list
+  const derived = await app.inject({ method: "POST", url: `${base}/graph/derive`, headers: auth(s.token), payload: {} });
+  assert.equal(derived.statusCode, 200);
+  const graph = await app.inject({ method: "GET", url: `${base}/graph`, headers: auth(s.token) });
+  assert.ok((graph.json().nodes as unknown[]).length >= 1);
+  const node = await app.inject({ method: "POST", url: `${base}/graph/nodes`, headers: auth(s.token), payload: { kind: "team", ref: "team:x" } });
+  assert.equal(node.statusCode, 200);
+
+  // search (with filters exercised)
+  const search = await app.inject({ method: "GET", url: `${base}/decisions/search?q=api&status=binding&origin=ingested&from=2000-01-01&to=2100-01-01`, headers: auth(s.token) });
+  assert.equal(search.statusCode, 200);
+  assert.ok(Array.isArray(search.json().decisions));
+
+  // validation + membership negative paths (branch coverage)
+  const graphNodeBad = await app.inject({ method: "POST", url: `${base}/graph/nodes`, headers: auth(s.token), payload: {} });
+  assert.equal(graphNodeBad.statusCode, 400);
+  const graphEdgeBad = await app.inject({ method: "POST", url: `${base}/graph/edges`, headers: auth(s.token), payload: { fromId: "x" } });
+  assert.equal(graphEdgeBad.statusCode, 400);
+  const confirmForbidden = await app.inject({ method: "POST", url: `/orgs/${s.orgId}/decisions/${crypto.randomUUID()}/confirm`, headers: auth(s.outsiderToken), payload: {} });
+  assert.equal(confirmForbidden.statusCode, 403);
+  const rejectForbidden = await app.inject({ method: "POST", url: `/orgs/${s.orgId}/decisions/${crypto.randomUUID()}/reject`, headers: auth(s.outsiderToken), payload: {} });
+  assert.equal(rejectForbidden.statusCode, 403);
+
+  if (env.LOCKSTEP_INGEST_TOKEN) {
+    const wtok = { "x-lockstep-ingest-token": env.LOCKSTEP_INGEST_TOKEN };
+    const wmBad = await app.inject({ method: "POST", url: "/ingest/watermark", headers: wtok, payload: { orgId: s.orgId } });
+    assert.equal(wmBad.statusCode, 400);
+    const finBad = await app.inject({ method: "POST", url: `/ingest/connections/${connectionId}/finalize`, headers: wtok, payload: {} });
+    assert.equal(finBad.statusCode, 400);
+    const emptyItems = await app.inject({ method: "POST", url: "/ingest/proposed-decisions", headers: wtok, payload: { items: [] } });
+    assert.equal(emptyItems.json().filed, 0);
+  }
+});

--- a/packages/core/src/api/routes/ingest.ts
+++ b/packages/core/src/api/routes/ingest.ts
@@ -1,0 +1,246 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { and, eq } from "drizzle-orm";
+import { withSystem } from "../../db/rls.js";
+import { members } from "../../db/schema.js";
+import { env } from "../../env.js";
+import {
+  listWork,
+  setWatermark,
+  finalizeConnection,
+  createConnection,
+  listConnections,
+  addAllowlist,
+  listAllowlist,
+} from "../../ingest/ingest-service.js";
+import {
+  fileProposedDecision,
+  confirmDecision,
+  rejectDecision,
+  listDecisions,
+  listProvenancesForProject,
+} from "../../ledger/ledger-service.js";
+import { deriveGraph, listGraph, addNode, addEdge } from "../../graph/graph-service.js";
+
+/** Gate the worker endpoints on the shared ingest service token. */
+function workerAuthed(req: FastifyRequest, reply: FastifyReply): boolean {
+  const expected = env.LOCKSTEP_INGEST_TOKEN;
+  const got = req.headers["x-lockstep-ingest-token"];
+  if (!expected || got !== expected) {
+    reply.code(401).send({ error: "ingest token required" });
+    return false;
+  }
+  return true;
+}
+
+/** Resolve the caller's member id in an org (principal must be a member), else 403. */
+async function ensureMember(req: FastifyRequest, reply: FastifyReply, orgId: string): Promise<string | null> {
+  const p = req.principal;
+  if (!p) {
+    reply.code(401).send({ error: "unauthorized" });
+    return null;
+  }
+  const memberId = await withSystem(async (tx) => {
+    const m = (
+      await tx
+        .select()
+        .from(members)
+        .where(and(eq(members.orgId, orgId), eq(members.principalId, p.id)))
+        .limit(1)
+    )[0];
+    return m?.id ?? null;
+  });
+  if (!memberId) {
+    reply.code(403).send({ error: "not a member of this org" });
+    return null;
+  }
+  return memberId;
+}
+
+export async function ingestRoutes(app: FastifyInstance): Promise<void> {
+  /* ─── Worker endpoints (service-token auth) ─── */
+
+  // The worker pulls all sweepable work (active connections + enabled allowlist + watermarks).
+  app.get("/ingest/work", async (req, reply) => {
+    if (!workerAuthed(req, reply)) return;
+    return { work: await listWork() };
+  });
+
+  // The worker files distilled proposed decisions (idempotent per content hash).
+  app.post("/ingest/proposed-decisions", async (req, reply) => {
+    if (!workerAuthed(req, reply)) return;
+    const b = req.body as {
+      items?: Array<{
+        orgId: string;
+        projectId: string;
+        scopeKind: string;
+        scopeRef: string;
+        ruleText: string;
+        decisionType?: string;
+        provenance: unknown;
+        connectionId: string;
+        externalId: string;
+        contentHash: string;
+        confidence?: number;
+      }>;
+    };
+    const items = b?.items ?? [];
+    const results = [];
+    for (const it of items) {
+      const r = await fileProposedDecision(it.orgId, {
+        projectId: it.projectId,
+        scopeKind: it.scopeKind,
+        scopeRef: it.scopeRef,
+        ruleText: it.ruleText,
+        decisionType: it.decisionType,
+        provenance: it.provenance,
+        connectionId: it.connectionId,
+        externalId: it.externalId,
+        contentHash: it.contentHash,
+        confidence: it.confidence,
+      });
+      results.push(r);
+    }
+    return {
+      filed: results.filter((r) => !r.deduped && !r.fused).length,
+      fused: results.filter((r) => r.fused).length,
+      deduped: results.filter((r) => r.deduped).length,
+    };
+  });
+
+  app.post("/ingest/watermark", async (req, reply) => {
+    if (!workerAuthed(req, reply)) return;
+    const b = req.body as { orgId?: string; connectionId?: string; sourceRef?: string; cursor?: string };
+    if (!b?.orgId || !b?.connectionId || !b?.sourceRef || b.cursor === undefined) {
+      return reply.code(400).send({ error: "orgId, connectionId, sourceRef, cursor required" });
+    }
+    await setWatermark(b.orgId, b.connectionId, b.sourceRef, b.cursor);
+    return { ok: true };
+  });
+
+  // The worker marks a connection active once Composio OAuth has completed.
+  app.post("/ingest/connections/:id/finalize", async (req, reply) => {
+    if (!workerAuthed(req, reply)) return;
+    const { id } = req.params as { id: string };
+    const b = req.body as { connectedAccountId?: string };
+    if (!b?.connectedAccountId) return reply.code(400).send({ error: "connectedAccountId required" });
+    await finalizeConnection(id, b.connectedAccountId);
+    return { ok: true };
+  });
+
+  /* ─── Admin + review endpoints (principal + org membership) ─── */
+
+  app.post("/orgs/:orgId/projects/:projectId/connections", async (req, reply) => {
+    const { orgId, projectId } = req.params as { orgId: string; projectId: string };
+    const memberId = await ensureMember(req, reply, orgId);
+    if (!memberId) return;
+    const b = req.body as { tool?: string };
+    const tool = b?.tool ?? "slack";
+    // Composio "entity" = the project id, so all sources for a project share one connection identity.
+    return createConnection(orgId, { projectId, tool, entity: projectId, createdBy: memberId });
+  });
+
+  app.get("/orgs/:orgId/projects/:projectId/connections", async (req, reply) => {
+    const { orgId, projectId } = req.params as { orgId: string; projectId: string };
+    if (!(await ensureMember(req, reply, orgId))) return;
+    return { connections: await listConnections(orgId, projectId) };
+  });
+
+  app.post("/orgs/:orgId/projects/:projectId/allowlist", async (req, reply) => {
+    const { orgId, projectId } = req.params as { orgId: string; projectId: string };
+    if (!(await ensureMember(req, reply, orgId))) return;
+    const b = req.body as { connectionId?: string; sourceKind?: string; sourceRef?: string; sourceName?: string };
+    if (!b?.connectionId || !b?.sourceRef) return reply.code(400).send({ error: "connectionId, sourceRef required" });
+    return addAllowlist(orgId, {
+      projectId,
+      connectionId: b.connectionId,
+      sourceKind: b.sourceKind ?? "channel",
+      sourceRef: b.sourceRef,
+      sourceName: b.sourceName,
+    });
+  });
+
+  app.get("/orgs/:orgId/projects/:projectId/allowlist", async (req, reply) => {
+    const { orgId, projectId } = req.params as { orgId: string; projectId: string };
+    if (!(await ensureMember(req, reply, orgId))) return;
+    return { allowlist: await listAllowlist(orgId, projectId) };
+  });
+
+  // Review queue: proposed (ingested) decisions awaiting human confirmation.
+  app.get("/orgs/:orgId/projects/:projectId/proposed", async (req, reply) => {
+    const { orgId, projectId } = req.params as { orgId: string; projectId: string };
+    if (!(await ensureMember(req, reply, orgId))) return;
+    const decisions = await listDecisions(orgId, projectId, undefined, { status: "proposed" });
+    const provs = await listProvenancesForProject(orgId, projectId);
+    return { decisions: decisions.map((d) => ({ ...d, provenances: provs[d.id] ?? [] })) };
+  });
+
+  app.post("/orgs/:orgId/decisions/:id/confirm", async (req, reply) => {
+    const { orgId, id } = req.params as { orgId: string; id: string };
+    const memberId = await ensureMember(req, reply, orgId);
+    if (!memberId) return;
+    const b = req.body as { ruleText?: string; scopeKind?: string; scopeRef?: string } | undefined;
+    return confirmDecision(orgId, id, memberId, b);
+  });
+
+  // Human decision search: "what did we decide about X?" over the ledger, with filters.
+  app.get("/orgs/:orgId/projects/:projectId/decisions/search", async (req, reply) => {
+    const { orgId, projectId } = req.params as { orgId: string; projectId: string };
+    if (!(await ensureMember(req, reply, orgId))) return;
+    const { q, status, origin, from, to } = req.query as {
+      q?: string;
+      status?: string;
+      origin?: string;
+      from?: string;
+      to?: string;
+    };
+    let list = await listDecisions(orgId, projectId, undefined, { status, origin });
+    if (q && q.trim()) {
+      const needle = q.toLowerCase();
+      list = list.filter((d) => {
+        const prov = JSON.stringify(d.provenance ?? "").toLowerCase();
+        return `${d.ruleText} ${d.scopeRef}`.toLowerCase().includes(needle) || prov.includes(needle);
+      });
+    }
+    if (from) list = list.filter((d) => new Date(d.createdAt).getTime() >= new Date(from).getTime());
+    if (to) list = list.filter((d) => new Date(d.createdAt).getTime() <= new Date(to).getTime());
+    list.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return { decisions: list };
+  });
+
+  app.post("/orgs/:orgId/decisions/:id/reject", async (req, reply) => {
+    const { orgId, id } = req.params as { orgId: string; id: string };
+    const memberId = await ensureMember(req, reply, orgId);
+    if (!memberId) return;
+    return rejectDecision(orgId, id, memberId);
+  });
+
+  /* ─── Org graph ─── */
+
+  app.get("/orgs/:orgId/projects/:projectId/graph", async (req, reply) => {
+    const { orgId, projectId } = req.params as { orgId: string; projectId: string };
+    if (!(await ensureMember(req, reply, orgId))) return;
+    return listGraph(orgId, projectId);
+  });
+
+  app.post("/orgs/:orgId/projects/:projectId/graph/derive", async (req, reply) => {
+    const { orgId, projectId } = req.params as { orgId: string; projectId: string };
+    if (!(await ensureMember(req, reply, orgId))) return;
+    return deriveGraph(orgId, projectId);
+  });
+
+  app.post("/orgs/:orgId/projects/:projectId/graph/nodes", async (req, reply) => {
+    const { orgId, projectId } = req.params as { orgId: string; projectId: string };
+    if (!(await ensureMember(req, reply, orgId))) return;
+    const b = req.body as { kind?: string; ref?: string; label?: string };
+    if (!b?.kind || !b?.ref) return reply.code(400).send({ error: "kind, ref required" });
+    return addNode(orgId, { projectId, kind: b.kind, ref: b.ref, label: b.label });
+  });
+
+  app.post("/orgs/:orgId/projects/:projectId/graph/edges", async (req, reply) => {
+    const { orgId, projectId } = req.params as { orgId: string; projectId: string };
+    if (!(await ensureMember(req, reply, orgId))) return;
+    const b = req.body as { fromId?: string; toId?: string; kind?: string };
+    if (!b?.fromId || !b?.toId) return reply.code(400).send({ error: "fromId, toId required" });
+    return addEdge(orgId, { projectId, fromId: b.fromId, toId: b.toId, kind: b.kind });
+  });
+}

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -184,7 +184,12 @@ export const decisions = pgTable("decisions", {
   // agent/human override. Drives noise filtering, session-start ranking, and the binding model.
   impact: integer("impact").notNull().default(0),
   currentVersion: integer("current_version").notNull().default(0),
-  status: text("status").notNull().default("open"), // open | ack | binding | superseded
+  // proposed → awaiting human confirm (v2 ingested decisions); open | ack | binding | superseded are
+  // the agent-originated lifecycle; rejected → a proposed decision a human declined.
+  status: text("status").notNull().default("open"), // proposed | open | ack | binding | superseded | rejected
+  // Who authored this decision: an agent via propose_decision, or the v2 ingestion pipeline distilling
+  // it from a human tool (Slack/Jira/Notion). Ingested decisions land `proposed` until a human confirms.
+  origin: text("origin").notNull().default("agent"), // agent | ingested
   createdAt: createdAt(),
 });
 
@@ -425,4 +430,139 @@ export const auditEvents = pgTable(
     createdAt: createdAt(),
   },
   (t) => ({ byEntity: index("ix_audit_entity").on(t.entityKind, t.entityId) }),
+);
+
+/* ───────────────────────────── v2 ingestion (human-tool → decision ledger) ───────────────────────────── */
+
+/**
+ * A connected human-coordination tool for a project (Slack today; Jira/Notion later). Auth is held by
+ * the connector provider (Composio) — we store only the entity + connectedAccountId, never a token.
+ */
+export const sourceConnections = pgTable(
+  "source_connections",
+  {
+    id: id(),
+    orgId: orgId(),
+    projectId: uuid("project_id").notNull(),
+    tool: text("tool").notNull(), // slack | jira | notion | confluence
+    entity: text("entity").notNull(), // Composio entity id (we use the project id)
+    connectedAccountId: text("connected_account_id"), // Composio connection id once OAuth completes
+    status: text("status").notNull().default("pending"), // pending | active | revoked
+    createdBy: uuid("created_by"),
+    createdAt: createdAt(),
+  },
+  (t) => ({ byProject: index("ix_source_conn_project").on(t.projectId, t.tool) }),
+);
+
+/**
+ * The opt-in: nothing is swept unless a source (Slack channel, Jira project, Notion space) is listed
+ * here and enabled. This is the trust wedge — allowlisted sources only.
+ */
+export const ingestAllowlist = pgTable(
+  "ingest_allowlist",
+  {
+    id: id(),
+    orgId: orgId(),
+    projectId: uuid("project_id").notNull(),
+    connectionId: uuid("connection_id").notNull(),
+    sourceKind: text("source_kind").notNull(), // channel | project | space
+    sourceRef: text("source_ref").notNull(), // e.g. Slack channel id C0123
+    sourceName: text("source_name"), // human label, e.g. #eng-decisions
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: createdAt(),
+  },
+  (t) => ({ uqSource: uniqueIndex("uq_allowlist_conn_source").on(t.connectionId, t.sourceRef) }),
+);
+
+/** Incremental-sweep cursor per allowlisted source (e.g. latest Slack ts seen). */
+export const ingestWatermarks = pgTable(
+  "ingest_watermarks",
+  {
+    id: id(),
+    orgId: orgId(),
+    connectionId: uuid("connection_id").notNull(),
+    sourceRef: text("source_ref").notNull(),
+    cursor: text("cursor"), // opaque per-connector cursor (Slack: last ts)
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ uqWatermark: uniqueIndex("uq_watermark_conn_source").on(t.connectionId, t.sourceRef) }),
+);
+
+/**
+ * Idempotency + tuning audit: every conversation unit the funnel sees is hashed here so it is never
+ * re-distilled. Stores the outcome (distilled/discarded/proposed) + confidence, not the raw content.
+ */
+export const ingestArtifacts = pgTable(
+  "ingest_artifacts",
+  {
+    id: id(),
+    orgId: orgId(),
+    connectionId: uuid("connection_id").notNull(),
+    externalId: text("external_id").notNull(), // e.g. Slack channel/threadTs
+    contentHash: text("content_hash").notNull(), // sha256 of the unit's content
+    status: text("status").notNull(), // discarded | proposed | question
+    confidence: integer("confidence"), // 0..100 (integer for simplicity)
+    decisionId: uuid("decision_id"), // set when it produced a proposed decision
+    createdAt: createdAt(),
+  },
+  (t) => ({ uqArtifact: uniqueIndex("uq_artifact_conn_ext_hash").on(t.connectionId, t.externalId, t.contentHash) }),
+);
+
+/**
+ * One decision, many provenances. When the funnel distills a decision that is semantically the same as
+ * an existing one (in the same scope) — even from a different tool — we attach a provenance row here
+ * instead of minting a duplicate. Each row is one source that evidences the decision.
+ */
+export const decisionProvenances = pgTable(
+  "decision_provenances",
+  {
+    id: id(),
+    orgId: orgId(),
+    decisionId: uuid("decision_id").notNull(),
+    source: text("source").notNull(), // slack | jira | notion | confluence | agent
+    externalId: text("external_id"), // thread/issue/page id
+    url: text("url"),
+    evidence: jsonb("evidence"), // [{externalId, quote}]
+    confidence: integer("confidence"), // 0..100
+    createdAt: createdAt(),
+  },
+  (t) => ({
+    byDecision: index("ix_provenance_decision").on(t.decisionId),
+    uqSource: uniqueIndex("uq_provenance_decision_source").on(t.decisionId, t.source, t.externalId),
+  }),
+);
+
+/* ───────────────────────────── v2 org graph (impact beyond code surfaces) ───────────────────────────── */
+
+/** Non-code nodes: teams, projects, docs, people, topics — auto-derived from connectors + human fixes. */
+export const graphNodes = pgTable(
+  "graph_nodes",
+  {
+    id: id(),
+    orgId: orgId(),
+    projectId: uuid("project_id").notNull(),
+    kind: text("kind").notNull(), // team | project | doc | person | topic | surface
+    ref: text("ref").notNull(), // stable key within kind (e.g. topic:auth, person:@alice)
+    label: text("label"),
+    source: text("source").notNull().default("derived"), // derived | manual
+    createdAt: createdAt(),
+  },
+  (t) => ({ uqNode: uniqueIndex("uq_graph_node").on(t.projectId, t.kind, t.ref) }),
+);
+
+/** Edges connect nodes (e.g. person → topic they work on; topic → surface it governs). */
+export const graphEdges = pgTable(
+  "graph_edges",
+  {
+    id: id(),
+    orgId: orgId(),
+    projectId: uuid("project_id").notNull(),
+    fromId: uuid("from_id").notNull(),
+    toId: uuid("to_id").notNull(),
+    kind: text("kind").notNull().default("relates"), // relates | owns | member | governs
+    weight: integer("weight").notNull().default(1),
+    source: text("source").notNull().default("derived"),
+    createdAt: createdAt(),
+  },
+  (t) => ({ uqEdge: uniqueIndex("uq_graph_edge").on(t.projectId, t.fromId, t.toId, t.kind) }),
 );

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -22,6 +22,11 @@ const schema = z.object({
 
   SLACK_BOT_TOKEN: z.string().optional(),
 
+  // v2 ingestion: Composio connector key (worker + OAuth) and the shared service token the ingest
+  // worker presents to the /ingest/* worker endpoints. Both optional so core boots without ingestion.
+  COMPOSIO_API_KEY: z.string().optional(),
+  LOCKSTEP_INGEST_TOKEN: z.string().optional(),
+
   LOCKSTEP_DEPLOYMENT: z.enum(["cloud", "self-host"]).default("self-host"),
 
   // Dev-only login bypass (never honored when NODE_ENV=production).

--- a/packages/core/src/graph/graph-service.test.ts
+++ b/packages/core/src/graph/graph-service.test.ts
@@ -1,0 +1,68 @@
+/** Unit tests for the org-graph service (derive / list / manual node+edge). Real Postgres. */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { withSystem } from "../db/rls.js";
+import { orgs, principals, members, projects } from "../db/schema.js";
+import { fileProposedDecision } from "../ledger/ledger-service.js";
+import { deriveGraph, listGraph, addNode, addEdge } from "./graph-service.js";
+import { randomUUID } from "node:crypto";
+
+function one<T>(rows: T[]): T {
+  const r = rows[0];
+  if (!r) throw new Error("expected a row");
+  return r;
+}
+let seq = Date.now() + 900_000_000;
+const uid = (): number => ++seq;
+
+async function setup() {
+  const n = uid();
+  return withSystem(async (tx) => {
+    const org = one(await tx.insert(orgs).values({ name: `GraphCo-${n}` }).returning());
+    const p = one(await tx.insert(principals).values({ githubUserId: uid(), githubLogin: `dev-${n}` }).returning());
+    const m = one(
+      await tx.insert(members).values({ orgId: org.id, principalId: p.id, githubUserId: p.githubUserId, githubLogin: `dev-${n}` }).returning(),
+    );
+    const proj = one(await tx.insert(projects).values({ orgId: org.id, name: "g", createdBy: m.id }).returning());
+    return { orgId: org.id, projectId: proj.id, login: `dev-${n}` };
+  });
+}
+
+test("deriveGraph builds project + person + topic nodes and edges, idempotently", async () => {
+  const s = await setup();
+  await fileProposedDecision(s.orgId, {
+    projectId: s.projectId,
+    scopeKind: "topic",
+    scopeRef: "topic:oncall",
+    ruleText: "On-call rotates weekly on Mondays.",
+    provenance: { source: "slack", evidence: [{ externalId: "t1", quote: "rotate weekly" }], decidedBy: ["@x", "@y"] },
+    connectionId: randomUUID(),
+    externalId: "t1",
+    contentHash: "h1",
+    confidence: 80,
+  });
+
+  const first = await deriveGraph(s.orgId, s.projectId);
+  const second = await deriveGraph(s.orgId, s.projectId);
+  assert.deepEqual(first, second, "derive is idempotent");
+
+  const g = await listGraph(s.orgId, s.projectId);
+  assert.ok(g.nodes.some((n) => n.kind === "project"));
+  assert.ok(g.nodes.some((n) => n.kind === "topic" && n.ref === "topic:oncall"));
+  assert.ok(g.nodes.some((n) => n.kind === "person" && n.ref === `person:${s.login}`), "member became a person node");
+  assert.ok(g.nodes.some((n) => n.kind === "person" && n.ref === "person:x"), "participant became a person node");
+  // topic connected to its 2 participants
+  const topic = g.nodes.find((n) => n.kind === "topic")!;
+  const topicEdges = g.edges.filter((e) => e.fromId === topic.id || e.toId === topic.id);
+  assert.ok(topicEdges.length >= 3, "governs project + relates to 2 participants");
+});
+
+test("addNode and addEdge create manual graph entries", async () => {
+  const s = await setup();
+  const a = await addNode(s.orgId, { projectId: s.projectId, kind: "team", ref: "team:platform", label: "Platform" });
+  const b = await addNode(s.orgId, { projectId: s.projectId, kind: "topic", ref: "topic:auth" });
+  await addEdge(s.orgId, { projectId: s.projectId, fromId: a.id, toId: b.id, kind: "owns" });
+  const g = await listGraph(s.orgId, s.projectId);
+  assert.ok(g.nodes.find((n) => n.id === a.id && n.source === "manual"));
+  assert.ok(g.edges.find((e) => e.fromId === a.id && e.toId === b.id && e.kind === "owns"));
+});

--- a/packages/core/src/graph/graph-service.ts
+++ b/packages/core/src/graph/graph-service.ts
@@ -1,0 +1,140 @@
+import { and, eq } from "drizzle-orm";
+import { withOrg, type Tx } from "../db/rls.js";
+import { graphNodes, graphEdges, members, decisions, decisionVersions } from "../db/schema.js";
+
+/**
+ * The org graph gives non-code decisions a blast radius. Nodes are teams/projects/docs/people/topics;
+ * edges connect them. v2 auto-derives the obvious structure from what we already know (members, and the
+ * people who participated in each distilled decision), and lets a human correct it. impactForScopeTx
+ * reads this graph for topic-scoped decisions.
+ */
+
+async function upsertNodeTx(
+  tx: Tx,
+  orgId: string,
+  projectId: string,
+  kind: string,
+  ref: string,
+  label: string,
+  source = "derived",
+): Promise<string> {
+  const existing = (
+    await tx
+      .select()
+      .from(graphNodes)
+      .where(and(eq(graphNodes.projectId, projectId), eq(graphNodes.kind, kind), eq(graphNodes.ref, ref)))
+      .limit(1)
+  )[0];
+  if (existing) return existing.id;
+  const row = (await tx.insert(graphNodes).values({ orgId, projectId, kind, ref, label, source }).returning())[0]!;
+  return row.id;
+}
+
+async function upsertEdgeTx(
+  tx: Tx,
+  orgId: string,
+  projectId: string,
+  fromId: string,
+  toId: string,
+  kind: string,
+  source = "derived",
+): Promise<void> {
+  const existing = (
+    await tx
+      .select()
+      .from(graphEdges)
+      .where(
+        and(
+          eq(graphEdges.projectId, projectId),
+          eq(graphEdges.fromId, fromId),
+          eq(graphEdges.toId, toId),
+          eq(graphEdges.kind, kind),
+        ),
+      )
+      .limit(1)
+  )[0];
+  if (existing) return;
+  await tx.insert(graphEdges).values({ orgId, projectId, fromId, toId, kind, source });
+}
+
+/** Rebuild the derived portion of the graph from members + distilled decisions. Idempotent. */
+export async function deriveGraph(
+  orgId: string,
+  projectId: string,
+): Promise<{ nodes: number; edges: number }> {
+  return withOrg(orgId, async (tx) => {
+    const projectNode = await upsertNodeTx(tx, orgId, projectId, "project", `project:${projectId}`, "project");
+
+    for (const m of await tx.select().from(members).where(eq(members.orgId, orgId))) {
+      const pid = await upsertNodeTx(tx, orgId, projectId, "person", `person:${m.githubLogin}`, m.githubLogin);
+      await upsertEdgeTx(tx, orgId, projectId, pid, projectNode, "member");
+    }
+
+    const ds = await tx.select().from(decisions).where(eq(decisions.projectId, projectId));
+    for (const d of ds) {
+      if (d.status === "rejected") continue;
+      if (d.scopeKind === "topic") {
+        const topicId = await upsertNodeTx(tx, orgId, projectId, "topic", d.scopeRef, d.scopeRef.replace(/^topic:/, ""));
+        await upsertEdgeTx(tx, orgId, projectId, topicId, projectNode, "governs");
+        // People who participated (decidedBy in the version provenance) → edges to the topic.
+        const v = (
+          await tx
+            .select()
+            .from(decisionVersions)
+            .where(and(eq(decisionVersions.decisionId, d.id), eq(decisionVersions.version, d.currentVersion)))
+            .limit(1)
+        )[0];
+        const decidedBy = ((v?.provenance as { decidedBy?: string[] })?.decidedBy ?? []).filter(Boolean);
+        for (const who of decidedBy) {
+          const handle = who.replace(/^@/, "");
+          const pid = await upsertNodeTx(tx, orgId, projectId, "person", `person:${handle}`, handle);
+          await upsertEdgeTx(tx, orgId, projectId, topicId, pid, "relates");
+        }
+      } else if (d.scopeKind === "surface" || d.scopeKind === "contract" || d.scopeKind === "shared") {
+        const sid = await upsertNodeTx(tx, orgId, projectId, "surface", d.scopeRef, d.scopeRef);
+        await upsertEdgeTx(tx, orgId, projectId, sid, projectNode, "governs");
+      }
+    }
+
+    const nodes = (await tx.select().from(graphNodes).where(eq(graphNodes.projectId, projectId))).length;
+    const edges = (await tx.select().from(graphEdges).where(eq(graphEdges.projectId, projectId))).length;
+    return { nodes, edges };
+  });
+}
+
+export async function listGraph(
+  orgId: string,
+  projectId: string,
+): Promise<{
+  nodes: Array<{ id: string; kind: string; ref: string; label: string | null; source: string }>;
+  edges: Array<{ fromId: string; toId: string; kind: string }>;
+}> {
+  return withOrg(orgId, async (tx) => {
+    const nodes = await tx.select().from(graphNodes).where(eq(graphNodes.projectId, projectId));
+    const edges = await tx.select().from(graphEdges).where(eq(graphEdges.projectId, projectId));
+    return {
+      nodes: nodes.map((n) => ({ id: n.id, kind: n.kind, ref: n.ref, label: n.label, source: n.source })),
+      edges: edges.map((e) => ({ fromId: e.fromId, toId: e.toId, kind: e.kind })),
+    };
+  });
+}
+
+export async function addNode(
+  orgId: string,
+  input: { projectId: string; kind: string; ref: string; label?: string },
+): Promise<{ id: string }> {
+  return withOrg(orgId, async (tx) => {
+    const id = await upsertNodeTx(tx, orgId, input.projectId, input.kind, input.ref, input.label ?? input.ref, "manual");
+    return { id };
+  });
+}
+
+export async function addEdge(
+  orgId: string,
+  input: { projectId: string; fromId: string; toId: string; kind?: string },
+): Promise<{ ok: boolean }> {
+  await withOrg(orgId, async (tx) => {
+    await upsertEdgeTx(tx, orgId, input.projectId, input.fromId, input.toId, input.kind ?? "relates", "manual");
+  });
+  return { ok: true };
+}

--- a/packages/core/src/ingest/ingest-service.test.ts
+++ b/packages/core/src/ingest/ingest-service.test.ts
@@ -1,0 +1,85 @@
+/** Unit tests for the ingest service (connections / allowlist / watermarks / work). Real Postgres. */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { withSystem } from "../db/rls.js";
+import { orgs, principals, members, projects } from "../db/schema.js";
+import {
+  createConnection,
+  listConnections,
+  finalizeConnection,
+  addAllowlist,
+  listAllowlist,
+  setWatermark,
+  listWork,
+} from "./ingest-service.js";
+
+function one<T>(rows: T[]): T {
+  const r = rows[0];
+  if (!r) throw new Error("expected a row");
+  return r;
+}
+let seq = Date.now() + 800_000_000;
+const uid = (): number => ++seq;
+
+async function setup() {
+  const n = uid();
+  return withSystem(async (tx) => {
+    const org = one(await tx.insert(orgs).values({ name: `SvcCo-${n}` }).returning());
+    const p = one(await tx.insert(principals).values({ githubUserId: uid(), githubLogin: `u-${n}` }).returning());
+    const m = one(
+      await tx.insert(members).values({ orgId: org.id, principalId: p.id, githubUserId: p.githubUserId, githubLogin: `u-${n}` }).returning(),
+    );
+    const proj = one(await tx.insert(projects).values({ orgId: org.id, name: "svc", createdBy: m.id }).returning());
+    return { orgId: org.id, projectId: proj.id, memberId: m.id };
+  });
+}
+
+test("createConnection is idempotent per (project, tool)", async () => {
+  const s = await setup();
+  const a = await createConnection(s.orgId, { projectId: s.projectId, tool: "slack", entity: s.projectId, createdBy: s.memberId });
+  const b = await createConnection(s.orgId, { projectId: s.projectId, tool: "slack", entity: s.projectId, createdBy: s.memberId });
+  assert.equal(a.connectionId, b.connectionId);
+  const conns = await listConnections(s.orgId, s.projectId);
+  assert.equal(conns.filter((c) => c.tool === "slack").length, 1);
+  assert.equal(conns[0]!.status, "pending");
+});
+
+test("allowlist add is an upsert that re-enables", async () => {
+  const s = await setup();
+  const { connectionId } = await createConnection(s.orgId, { projectId: s.projectId, tool: "slack", entity: s.projectId, createdBy: s.memberId });
+  const first = await addAllowlist(s.orgId, { projectId: s.projectId, connectionId, sourceKind: "channel", sourceRef: "C1", sourceName: "#eng" });
+  const again = await addAllowlist(s.orgId, { projectId: s.projectId, connectionId, sourceKind: "channel", sourceRef: "C1" });
+  assert.equal(first.id, again.id, "same source ref → same row");
+  const list = await listAllowlist(s.orgId, s.projectId);
+  assert.equal(list.length, 1);
+  assert.equal(list[0]!.enabled, true);
+});
+
+test("setWatermark inserts then updates the cursor", async () => {
+  const s = await setup();
+  const { connectionId } = await createConnection(s.orgId, { projectId: s.projectId, tool: "slack", entity: s.projectId, createdBy: s.memberId });
+  await setWatermark(s.orgId, connectionId, "C1", "100.0");
+  await setWatermark(s.orgId, connectionId, "C1", "200.0");
+  await finalizeConnection(connectionId, "acct-123");
+  await addAllowlist(s.orgId, { projectId: s.projectId, connectionId, sourceKind: "channel", sourceRef: "C1", sourceName: "#eng" });
+  const work = (await listWork()).find((w) => w.connectionId === connectionId);
+  assert.ok(work, "active connection with an enabled source appears in work");
+  assert.equal(work!.connectedAccountId, "acct-123");
+  assert.equal(work!.sources.find((x) => x.sourceRef === "C1")!.cursor, "200.0", "latest watermark");
+});
+
+test("listWork excludes connections with no enabled allowlisted source", async () => {
+  const s = await setup();
+  const { connectionId } = await createConnection(s.orgId, { projectId: s.projectId, tool: "jira", entity: s.projectId, createdBy: s.memberId });
+  await finalizeConnection(connectionId, "acct-x"); // active but no allowlist
+  const work = (await listWork()).find((w) => w.connectionId === connectionId);
+  assert.equal(work, undefined);
+});
+
+test("listWork excludes pending (not-yet-connected) connections", async () => {
+  const s = await setup();
+  const { connectionId } = await createConnection(s.orgId, { projectId: s.projectId, tool: "notion", entity: s.projectId, createdBy: s.memberId });
+  await addAllowlist(s.orgId, { projectId: s.projectId, connectionId, sourceKind: "database", sourceRef: "db1" });
+  const work = (await listWork()).find((w) => w.connectionId === connectionId);
+  assert.equal(work, undefined, "pending connection is not swept");
+});

--- a/packages/core/src/ingest/ingest-service.ts
+++ b/packages/core/src/ingest/ingest-service.ts
@@ -1,0 +1,195 @@
+import { and, eq } from "drizzle-orm";
+import { withOrg, withSystem } from "../db/rls.js";
+import { sourceConnections, ingestAllowlist, ingestWatermarks } from "../db/schema.js";
+
+function one<T>(rows: T[]): T {
+  const r = rows[0];
+  if (!r) throw new Error("expected a row");
+  return r;
+}
+
+export interface WorkSource {
+  sourceRef: string;
+  sourceName: string | null;
+  cursor: string | null;
+}
+export interface WorkItem {
+  orgId: string;
+  projectId: string;
+  connectionId: string;
+  tool: string;
+  entity: string;
+  connectedAccountId: string | null;
+  sources: WorkSource[];
+}
+
+/**
+ * Cross-org enumeration of everything the worker should sweep: active connections with at least one
+ * enabled allowlisted source, each carrying its watermark cursor. Trusted system read (the worker is
+ * authenticated by the shared ingest token). Only allowlisted sources are ever returned.
+ */
+export async function listWork(): Promise<WorkItem[]> {
+  return withSystem(async (tx) => {
+    const conns = await tx.select().from(sourceConnections).where(eq(sourceConnections.status, "active"));
+    const items: WorkItem[] = [];
+    for (const c of conns) {
+      const allow = await tx
+        .select()
+        .from(ingestAllowlist)
+        .where(and(eq(ingestAllowlist.connectionId, c.id), eq(ingestAllowlist.enabled, true)));
+      if (allow.length === 0) continue;
+      const marks = await tx.select().from(ingestWatermarks).where(eq(ingestWatermarks.connectionId, c.id));
+      const cursorFor = (ref: string) => marks.find((m) => m.sourceRef === ref)?.cursor ?? null;
+      items.push({
+        orgId: c.orgId,
+        projectId: c.projectId,
+        connectionId: c.id,
+        tool: c.tool,
+        entity: c.entity,
+        connectedAccountId: c.connectedAccountId,
+        sources: allow.map((a) => ({ sourceRef: a.sourceRef, sourceName: a.sourceName, cursor: cursorFor(a.sourceRef) })),
+      });
+    }
+    return items;
+  });
+}
+
+/** Advance the incremental-sweep cursor for one allowlisted source. */
+export async function setWatermark(
+  orgId: string,
+  connectionId: string,
+  sourceRef: string,
+  cursor: string,
+): Promise<void> {
+  await withOrg(orgId, async (tx) => {
+    const existing = (
+      await tx
+        .select()
+        .from(ingestWatermarks)
+        .where(and(eq(ingestWatermarks.connectionId, connectionId), eq(ingestWatermarks.sourceRef, sourceRef)))
+        .limit(1)
+    )[0];
+    if (existing) {
+      await tx
+        .update(ingestWatermarks)
+        .set({ cursor, updatedAt: new Date() })
+        .where(eq(ingestWatermarks.id, existing.id));
+    } else {
+      await tx.insert(ingestWatermarks).values({ orgId, connectionId, sourceRef, cursor });
+    }
+  });
+}
+
+export async function createConnection(
+  orgId: string,
+  input: { projectId: string; tool: string; entity: string; createdBy: string },
+): Promise<{ connectionId: string; entity: string }> {
+  return withOrg(orgId, async (tx) => {
+    const existing = (
+      await tx
+        .select()
+        .from(sourceConnections)
+        .where(
+          and(
+            eq(sourceConnections.projectId, input.projectId),
+            eq(sourceConnections.tool, input.tool),
+          ),
+        )
+        .limit(1)
+    )[0];
+    if (existing) return { connectionId: existing.id, entity: existing.entity };
+    const c = one(
+      await tx
+        .insert(sourceConnections)
+        .values({
+          orgId,
+          projectId: input.projectId,
+          tool: input.tool,
+          entity: input.entity,
+          status: "pending",
+          createdBy: input.createdBy,
+        })
+        .returning(),
+    );
+    return { connectionId: c.id, entity: c.entity };
+  });
+}
+
+/** Mark a connection active once Composio OAuth completed (called by the worker after `connect`). */
+export async function finalizeConnection(connectionId: string, connectedAccountId: string): Promise<void> {
+  await withSystem(async (tx) => {
+    await tx
+      .update(sourceConnections)
+      .set({ connectedAccountId, status: "active" })
+      .where(eq(sourceConnections.id, connectionId));
+  });
+}
+
+export async function listConnections(
+  orgId: string,
+  projectId: string,
+): Promise<Array<{ id: string; tool: string; entity: string; status: string; connectedAccountId: string | null }>> {
+  return withOrg(orgId, async (tx) => {
+    const rows = await tx.select().from(sourceConnections).where(eq(sourceConnections.projectId, projectId));
+    return rows.map((r) => ({
+      id: r.id,
+      tool: r.tool,
+      entity: r.entity,
+      status: r.status,
+      connectedAccountId: r.connectedAccountId,
+    }));
+  });
+}
+
+export async function addAllowlist(
+  orgId: string,
+  input: { projectId: string; connectionId: string; sourceKind: string; sourceRef: string; sourceName?: string },
+): Promise<{ id: string }> {
+  return withOrg(orgId, async (tx) => {
+    const existing = (
+      await tx
+        .select()
+        .from(ingestAllowlist)
+        .where(
+          and(eq(ingestAllowlist.connectionId, input.connectionId), eq(ingestAllowlist.sourceRef, input.sourceRef)),
+        )
+        .limit(1)
+    )[0];
+    if (existing) {
+      await tx.update(ingestAllowlist).set({ enabled: true, sourceName: input.sourceName ?? existing.sourceName }).where(eq(ingestAllowlist.id, existing.id));
+      return { id: existing.id };
+    }
+    const a = one(
+      await tx
+        .insert(ingestAllowlist)
+        .values({
+          orgId,
+          projectId: input.projectId,
+          connectionId: input.connectionId,
+          sourceKind: input.sourceKind,
+          sourceRef: input.sourceRef,
+          sourceName: input.sourceName ?? null,
+          enabled: true,
+        })
+        .returning(),
+    );
+    return { id: a.id };
+  });
+}
+
+export async function listAllowlist(
+  orgId: string,
+  projectId: string,
+): Promise<Array<{ id: string; connectionId: string; sourceKind: string; sourceRef: string; sourceName: string | null; enabled: boolean }>> {
+  return withOrg(orgId, async (tx) => {
+    const rows = await tx.select().from(ingestAllowlist).where(eq(ingestAllowlist.projectId, projectId));
+    return rows.map((r) => ({
+      id: r.id,
+      connectionId: r.connectionId,
+      sourceKind: r.sourceKind,
+      sourceRef: r.sourceRef,
+      sourceName: r.sourceName,
+      enabled: r.enabled,
+    }));
+  });
+}

--- a/packages/core/src/ingest/ingest.e2e.test.ts
+++ b/packages/core/src/ingest/ingest.e2e.test.ts
@@ -1,0 +1,237 @@
+/**
+ * End-to-end proof of the v2 ingestion loop at the service layer:
+ *   distilled unit → fileProposedDecision (proposed/ingested, idempotent) → confirmDecision → binding,
+ *   and it shows up in the ledger the agent briefing reads. Cross-cutting proposals stay open until ack.
+ *
+ * Runs against a real Postgres (DATABASE_URL), like loop.e2e.test.ts. No network, no Composio, no LLM —
+ * this is the StubConnector → core path (the funnel's LLM stages are exercised in the real-Slack test).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { withSystem } from "../db/rls.js";
+import { orgs, principals, members, projects, repos } from "../db/schema.js";
+import {
+  fileProposedDecision,
+  confirmDecision,
+  rejectDecision,
+  listDecisions,
+  listProvenancesForProject,
+  registerDependency,
+} from "../ledger/ledger-service.js";
+import { deriveGraph } from "../graph/graph-service.js";
+
+function one<T>(rows: T[]): T {
+  const r = rows[0];
+  if (!r) throw new Error("expected a row");
+  return r;
+}
+
+// Offset well past the other e2e file's Date.now()-based seq so github_user_ids never collide in the
+// shared test-runner process.
+let seq = Date.now() + 500_000_000;
+const uid = (): number => ++seq;
+
+async function setup() {
+  const n = uid();
+  return withSystem(async (tx) => {
+    const org = one(await tx.insert(orgs).values({ name: `IngestCo-${n}` }).returning());
+    const pAlice = one(
+      await tx.insert(principals).values({ githubUserId: uid(), githubLogin: `alice-${n}` }).returning(),
+    );
+    const alice = one(
+      await tx
+        .insert(members)
+        .values({ orgId: org.id, principalId: pAlice.id, githubUserId: pAlice.githubUserId, githubLogin: `alice-${n}` })
+        .returning(),
+    );
+    const proj = one(await tx.insert(projects).values({ orgId: org.id, name: "ingest", createdBy: alice.id }).returning());
+    const consumerRepo = one(
+      await tx
+        .insert(repos)
+        .values({ orgId: org.id, projectId: proj.id, gitRemote: `github.com/ingestco/web-${n}` })
+        .returning(),
+    );
+    return { orgId: org.id, projectId: proj.id, alice: alice.id, consumerRepo: consumerRepo.id };
+  });
+}
+
+test("INGEST: a distilled unit files a proposed/ingested decision, idempotently", async () => {
+  const s = await setup();
+  const connectionId = randomUUID();
+  const args = {
+    projectId: s.projectId,
+    scopeKind: "topic",
+    scopeRef: "topic:authentication",
+    ruleText: "Auth tokens are JWT with 15-minute expiry.",
+    decisionType: "rule",
+    provenance: {
+      source: "slack",
+      connectionId,
+      externalId: "C_STUB/1699000001.0001",
+      evidence: [{ externalId: "C_STUB/1699000001.0001", quote: "let's lock it: JWT with 15-minute expiry" }],
+      confidence: 0.9,
+    },
+    connectionId,
+    externalId: "C_STUB/1699000001.0001",
+    contentHash: "hash-abc",
+    confidence: 90,
+  };
+
+  const first = await fileProposedDecision(s.orgId, args);
+  assert.equal(first.deduped, false);
+  assert.ok(first.decisionId);
+
+  // Re-seeing the same unit must not mint a duplicate (idempotency backstop).
+  const again = await fileProposedDecision(s.orgId, args);
+  assert.equal(again.deduped, true);
+  assert.equal(again.decisionId, first.decisionId);
+
+  const proposed = await listDecisions(s.orgId, s.projectId, undefined, { status: "proposed" });
+  const got = proposed.find((d) => d.id === first.decisionId);
+  assert.ok(got, "proposed decision is in the review queue");
+  assert.equal(got!.origin, "ingested");
+  assert.equal(got!.status, "proposed");
+  assert.ok(got!.ruleText.includes("JWT"));
+});
+
+test("INGEST: confirming an own-area proposal binds it and it enters the ledger the briefing reads", async () => {
+  const s = await setup();
+  const connectionId = randomUUID();
+  const filed = await fileProposedDecision(s.orgId, {
+    projectId: s.projectId,
+    scopeKind: "topic",
+    scopeRef: "topic:billing",
+    ruleText: "Invoices are generated in UTC and stored as immutable snapshots.",
+    provenance: { source: "slack", evidence: [{ externalId: "x", quote: "we bill in UTC, snapshots are immutable" }] },
+    connectionId,
+    externalId: "C_STUB/2",
+    contentHash: "hash-billing",
+    confidence: 88,
+  });
+
+  const confirmed = await confirmDecision(s.orgId, filed.decisionId, s.alice);
+  assert.equal(confirmed.impact, 0, "topic scope, no consumers → impact 0");
+  assert.equal(confirmed.status, "binding", "own-area confirmed decision binds");
+
+  // It's now an ordinary binding decision — exactly what the agent session-start briefing lists.
+  const all = await listDecisions(s.orgId, s.projectId);
+  const got = all.find((d) => d.id === filed.decisionId);
+  assert.ok(got);
+  assert.equal(got!.status, "binding");
+  assert.equal(got!.origin, "ingested");
+});
+
+test("INGEST: confirming a cross-cutting proposal stays open until an affected team acks", async () => {
+  const s = await setup();
+  const surface = "http:POST /orders";
+  await registerDependency(s.orgId, {
+    projectId: s.projectId,
+    memberId: s.alice,
+    consumerRepoId: s.consumerRepo,
+    producedSurface: surface,
+  });
+  const filed = await fileProposedDecision(s.orgId, {
+    projectId: s.projectId,
+    scopeKind: "surface",
+    scopeRef: surface,
+    ruleText: "Orders require an idempotency key.",
+    provenance: { source: "slack", evidence: [{ externalId: "y", quote: "orders must carry an idempotency key" }] },
+    connectionId: randomUUID(),
+    externalId: "C_STUB/3",
+    contentHash: "hash-orders",
+    confidence: 80,
+  });
+  const confirmed = await confirmDecision(s.orgId, filed.decisionId, s.alice);
+  assert.equal(confirmed.impact, 1, "one declared consumer → cross-cutting");
+  assert.equal(confirmed.status, "open", "cross-cutting confirmed decision awaits ack, does not bind yet");
+});
+
+test("FUSION: a similar decision from another tool attaches as provenance, not a duplicate", async () => {
+  const s = await setup();
+  const scopeRef = "topic:authentication";
+  const rule = "Auth tokens are JWT with 15-minute expiry.";
+
+  const slack = await fileProposedDecision(s.orgId, {
+    projectId: s.projectId,
+    scopeKind: "topic",
+    scopeRef,
+    ruleText: rule,
+    provenance: { source: "slack", evidence: [{ externalId: "sl1", quote: "lock it: JWT, 15 min" }] },
+    connectionId: randomUUID(),
+    externalId: "slack/1",
+    contentHash: "h-slack",
+    confidence: 90,
+  });
+  assert.equal(slack.fused, false);
+
+  // Same rule, different tool → should fuse into the slack decision.
+  const jira = await fileProposedDecision(s.orgId, {
+    projectId: s.projectId,
+    scopeKind: "topic",
+    scopeRef,
+    ruleText: "Auth tokens must be JWT with 15-minute expiry.",
+    provenance: { source: "jira", evidence: [{ externalId: "AUTH-12", quote: "JWT 15 min expiry" }] },
+    connectionId: randomUUID(),
+    externalId: "jira/AUTH-12",
+    contentHash: "h-jira",
+    confidence: 85,
+  });
+  assert.equal(jira.fused, true, "second source fuses");
+  assert.equal(jira.decisionId, slack.decisionId, "into the same decision");
+
+  const provs = await listProvenancesForProject(s.orgId, s.projectId);
+  const sources = (provs[slack.decisionId] ?? []).map((p) => p.source).sort();
+  assert.deepEqual(sources, ["jira", "slack"], "one decision, two provenances");
+
+  // Only one proposed decision exists for this scope.
+  const proposed = await listDecisions(s.orgId, s.projectId, scopeRef, { status: "proposed" });
+  assert.equal(proposed.length, 1);
+});
+
+test("GRAPH: a topic decision gets non-code impact from the org graph (participants)", async () => {
+  const s = await setup();
+  const filed = await fileProposedDecision(s.orgId, {
+    projectId: s.projectId,
+    scopeKind: "topic",
+    scopeRef: "topic:release-process",
+    ruleText: "Releases ship on Tuesdays behind a feature flag.",
+    provenance: {
+      source: "slack",
+      evidence: [{ externalId: "r1", quote: "we ship Tuesdays behind a flag" }],
+      decidedBy: ["@alice", "@bob", "@carol"],
+    },
+    connectionId: randomUUID(),
+    externalId: "slack/rel",
+    contentHash: "h-rel",
+    confidence: 88,
+  });
+
+  // Build the graph from members + this decision's participants.
+  const g = await deriveGraph(s.orgId, s.projectId);
+  assert.ok(g.nodes > 0 && g.edges > 0);
+
+  // Confirming now reads the graph: 3 participants → impact 3 → cross-cutting (stays open until ack).
+  const confirmed = await confirmDecision(s.orgId, filed.decisionId, s.alice);
+  assert.equal(confirmed.impact, 3, "topic impact = distinct participants in the graph");
+  assert.equal(confirmed.status, "open");
+});
+
+test("INGEST: a rejected proposal never appears as a binding decision", async () => {
+  const s = await setup();
+  const filed = await fileProposedDecision(s.orgId, {
+    projectId: s.projectId,
+    scopeKind: "topic",
+    scopeRef: "topic:noise",
+    ruleText: "Not actually a decision.",
+    provenance: { source: "slack", evidence: [{ externalId: "z", quote: "maybe we should..." }] },
+    connectionId: randomUUID(),
+    externalId: "C_STUB/4",
+    contentHash: "hash-noise",
+    confidence: 55,
+  });
+  const rejected = await rejectDecision(s.orgId, filed.decisionId, s.alice);
+  assert.equal(rejected.status, "rejected");
+  const proposed = await listDecisions(s.orgId, s.projectId, undefined, { status: "proposed" });
+  assert.equal(proposed.find((d) => d.id === filed.decisionId), undefined, "no longer in the review queue");
+});

--- a/packages/core/src/ledger/ledger-extra.test.ts
+++ b/packages/core/src/ledger/ledger-extra.test.ts
@@ -1,0 +1,142 @@
+/** Extra coverage for ledger-service: CAS versioning, confirm-with-edits, supersession, and the
+ *  v1 question/task/reconcile/query paths. Real Postgres. */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { withSystem } from "../db/rls.js";
+import { orgs, principals, members, projects, repos } from "../db/schema.js";
+import {
+  proposeDecision,
+  fileProposedDecision,
+  confirmDecision,
+  listDecisions,
+  askQuestion,
+  answerQuestion,
+  createTask,
+  completeTask,
+  recordChange,
+  reconcile,
+  queryLedger,
+  registerDependency,
+} from "./ledger-service.js";
+import { randomUUID } from "node:crypto";
+
+function one<T>(rows: T[]): T {
+  const r = rows[0];
+  if (!r) throw new Error("expected a row");
+  return r;
+}
+let seq = Date.now() + 300_000_000;
+const uid = (): number => ++seq;
+
+async function setup() {
+  const n = uid();
+  return withSystem(async (tx) => {
+    const org = one(await tx.insert(orgs).values({ name: `LxCo-${n}` }).returning());
+    const pa = one(await tx.insert(principals).values({ githubUserId: uid(), githubLogin: `a-${n}` }).returning());
+    const pb = one(await tx.insert(principals).values({ githubUserId: uid(), githubLogin: `b-${n}` }).returning());
+    const alice = one(await tx.insert(members).values({ orgId: org.id, principalId: pa.id, githubUserId: pa.githubUserId, githubLogin: `a-${n}` }).returning());
+    const bob = one(await tx.insert(members).values({ orgId: org.id, principalId: pb.id, githubUserId: pb.githubUserId, githubLogin: `b-${n}` }).returning());
+    const proj = one(await tx.insert(projects).values({ orgId: org.id, name: "lx", createdBy: alice.id }).returning());
+    const repo = one(await tx.insert(repos).values({ orgId: org.id, projectId: proj.id, gitRemote: `github.com/lx/svc-${n}` }).returning());
+    return { orgId: org.id, projectId: proj.id, alice: alice.id, bob: bob.id, bobLogin: `b-${n}`, repo: repo.id };
+  });
+}
+
+test("proposeDecision: version bumps on correct baseVersion, 409s on stale", async () => {
+  const s = await setup();
+  const scope = { scopeKind: "topic", scopeRef: `topic:cadence-${uid()}` };
+  const v1 = await proposeDecision(s.orgId, { projectId: s.projectId, memberId: s.alice, ...scope, ruleText: "ship weekly", baseVersion: 0 });
+  assert.equal(v1.version, 1);
+  const v2 = await proposeDecision(s.orgId, { projectId: s.projectId, memberId: s.alice, ...scope, ruleText: "ship daily", baseVersion: 1 });
+  assert.equal(v2.version, 2);
+  await assert.rejects(
+    proposeDecision(s.orgId, { projectId: s.projectId, memberId: s.alice, ...scope, ruleText: "stale", baseVersion: 0 }),
+    /stale base_version/,
+  );
+});
+
+test("confirmDecision with edits appends a new version and updates the rule text", async () => {
+  const s = await setup();
+  const filed = await fileProposedDecision(s.orgId, {
+    projectId: s.projectId,
+    scopeKind: "topic",
+    scopeRef: `topic:edit-${uid()}`,
+    ruleText: "original text",
+    provenance: { source: "slack", evidence: [{ externalId: "e", quote: "q" }] },
+    connectionId: randomUUID(),
+    externalId: `e-${uid()}`,
+    contentHash: `h-${uid()}`,
+    confidence: 80,
+  });
+  const res = await confirmDecision(s.orgId, filed.decisionId, s.alice, { ruleText: "edited on confirm" });
+  assert.equal(res.status, "binding");
+  const got = (await listDecisions(s.orgId, s.projectId)).find((d) => d.id === filed.decisionId)!;
+  assert.equal(got.version, 2, "edit appended a new version");
+  assert.equal(got.ruleText, "edited on confirm");
+});
+
+test("confirmDecision rejects a non-proposed decision", async () => {
+  const s = await setup();
+  const filed = await fileProposedDecision(s.orgId, {
+    projectId: s.projectId, scopeKind: "topic", scopeRef: `topic:once-${uid()}`, ruleText: "x",
+    provenance: { source: "slack", evidence: [{ externalId: "e", quote: "q" }] },
+    connectionId: randomUUID(), externalId: `e-${uid()}`, contentHash: `h-${uid()}`, confidence: 70,
+  });
+  await confirmDecision(s.orgId, filed.decisionId, s.alice);
+  await assert.rejects(confirmDecision(s.orgId, filed.decisionId, s.alice), /not proposed/);
+});
+
+test("fileProposedDecision flags supersession when a binding decision exists on the same scope", async () => {
+  const s = await setup();
+  const scopeRef = `topic:policy-${uid()}`;
+  // establish a binding decision (own-area, impact 0)
+  const first = await fileProposedDecision(s.orgId, {
+    projectId: s.projectId, scopeKind: "topic", scopeRef, ruleText: "Deploys happen on Fridays.",
+    provenance: { source: "slack", evidence: [{ externalId: "a", quote: "fridays" }] },
+    connectionId: randomUUID(), externalId: `a-${uid()}`, contentHash: `h-${uid()}`, confidence: 90,
+  });
+  await confirmDecision(s.orgId, first.decisionId, s.alice); // → binding
+  // a contradictory rule on the same scope
+  const second = await fileProposedDecision(s.orgId, {
+    projectId: s.projectId, scopeKind: "topic", scopeRef, ruleText: "Never deploy on weekdays; releases are Sunday night only.",
+    provenance: { source: "jira", evidence: [{ externalId: "b", quote: "sunday only" }] },
+    connectionId: randomUUID(), externalId: `b-${uid()}`, contentHash: `h-${uid()}`, confidence: 85,
+  });
+  assert.equal(second.fused, false, "different rule → not fused");
+  assert.equal(second.supersedes, first.decisionId, "flags the binding decision it may supersede");
+});
+
+test("questions, tasks, reconcile and query paths", async () => {
+  const s = await setup();
+  const surface = `http:POST /orders-${uid()}`;
+
+  const q = await askQuestion(s.orgId, { projectId: s.projectId, memberId: s.alice, body: "what is our retry policy?", scopeRef: surface });
+  const a = await answerQuestion(s.orgId, q.questionId, s.bob, "exponential backoff, max 5");
+  assert.equal(a.status, "answered");
+
+  const t = await createTask(s.orgId, { projectId: s.projectId, memberId: s.alice, title: "write the ADR", to: s.bobLogin });
+  const done = await completeTask(s.orgId, t.taskId, s.bob);
+  assert.equal(done.status, "done");
+
+  // reconcile: a contract surface with no binding decision is a violation
+  const before = await reconcile(s.orgId, s.projectId, [surface]);
+  assert.equal(before.ok, false);
+  assert.ok(before.violations.includes(surface));
+
+  // make it binding, then reconcile passes
+  await proposeDecision(s.orgId, { projectId: s.projectId, memberId: s.alice, scopeKind: "surface", scopeRef: surface, ruleText: "orders are idempotent", baseVersion: 0 });
+  const after = await reconcile(s.orgId, s.projectId, [surface]);
+  assert.equal(after.ok, true);
+
+  await recordChange(s.orgId, { projectId: s.projectId, repoId: s.repo, memberId: s.alice, summary: "changed orders route", surface });
+  const found = await queryLedger(s.orgId, s.projectId, "orders");
+  assert.ok(found.decisions.length + found.changes.length > 0, "query finds the decision/change");
+});
+
+test("registerDependency then listConsumers via reconcile stale dependents", async () => {
+  const s = await setup();
+  const surface = `http:GET /catalog-${uid()}`;
+  await registerDependency(s.orgId, { projectId: s.projectId, memberId: s.bob, consumerRepoId: s.repo, producedSurface: surface });
+  const rec = await reconcile(s.orgId, s.projectId, [surface]);
+  assert.ok(rec.staleDependents.some((d) => d.surface === surface));
+});

--- a/packages/core/src/ledger/ledger-service.ts
+++ b/packages/core/src/ledger/ledger-service.ts
@@ -12,6 +12,10 @@ import {
   tasks,
   members,
   repos,
+  ingestArtifacts,
+  decisionProvenances,
+  graphNodes,
+  graphEdges,
 } from "../db/schema.js";
 import { writeAudit } from "../audit/audit-service.js";
 import { fanoutChangeTx, fanoutToProjectTx } from "../routing/routing-engine.js";
@@ -54,7 +58,30 @@ async function impactForScopeTx(tx: Tx, projectId: string, scopeKind: string, sc
     const rs = await tx.select().from(repos).where(eq(repos.projectId, projectId));
     return Math.max(0, rs.length - 1);
   }
+  // Non-code decision: blast radius = how many people/teams the org graph links to this topic.
+  if (scopeKind === "topic") return topicImpactTx(tx, projectId, scopeRef);
   return 0;
+}
+
+/** Org-graph impact for a topic node: distinct person/team neighbours (0 if the graph isn't derived yet). */
+async function topicImpactTx(tx: Tx, projectId: string, topicRef: string): Promise<number> {
+  const node = (
+    await tx
+      .select()
+      .from(graphNodes)
+      .where(and(eq(graphNodes.projectId, projectId), eq(graphNodes.kind, "topic"), eq(graphNodes.ref, topicRef)))
+      .limit(1)
+  )[0];
+  if (!node) return 0;
+  const edges = await tx.select().from(graphEdges).where(eq(graphEdges.projectId, projectId));
+  const neighbourIds = new Set<string>();
+  for (const e of edges) {
+    if (e.fromId === node.id) neighbourIds.add(e.toId);
+    else if (e.toId === node.id) neighbourIds.add(e.fromId);
+  }
+  if (neighbourIds.size === 0) return 0;
+  const people = await tx.select().from(graphNodes).where(and(eq(graphNodes.projectId, projectId), eq(graphNodes.kind, "person")));
+  return people.filter((p) => neighbourIds.has(p.id)).length;
 }
 
 export interface ProposeInput {
@@ -197,20 +224,337 @@ export async function ackDecision(
   });
 }
 
+/* ───────────────────────────── v2: ingested (proposed) decisions ───────────────────────────── */
+
+const STOPWORDS = new Set(["the", "a", "an", "is", "are", "to", "of", "and", "or", "for", "with", "we", "our", "be", "on", "in"]);
+
+/** Cheap lexical similarity (Jaccard over content words) — the v1 dedup/fusion signal (no embeddings yet). */
+function similar(a: string, b: string): number {
+  const toks = (s: string) =>
+    new Set(
+      s
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, " ")
+        .split(/\s+/)
+        .filter((w) => w.length > 2 && !STOPWORDS.has(w)),
+    );
+  const A = toks(a);
+  const B = toks(b);
+  if (A.size === 0 || B.size === 0) return 0;
+  let inter = 0;
+  for (const w of A) if (B.has(w)) inter++;
+  return inter / (A.size + B.size - inter);
+}
+
+async function addProvenanceTx(
+  tx: Tx,
+  orgId: string,
+  decisionId: string,
+  prov: { source?: string; url?: string | null; evidence?: unknown; externalId?: string | null; confidence?: number },
+): Promise<void> {
+  const source = prov.source ?? "unknown";
+  const externalId = prov.externalId ?? null;
+  const existing = (
+    await tx
+      .select()
+      .from(decisionProvenances)
+      .where(
+        and(
+          eq(decisionProvenances.decisionId, decisionId),
+          eq(decisionProvenances.source, source),
+          externalId === null ? eq(decisionProvenances.externalId, "") : eq(decisionProvenances.externalId, externalId),
+        ),
+      )
+      .limit(1)
+  )[0];
+  if (existing) return;
+  await tx.insert(decisionProvenances).values({
+    orgId,
+    decisionId,
+    source,
+    externalId,
+    url: prov.url ?? null,
+    evidence: prov.evidence ?? null,
+    confidence: prov.confidence ?? null,
+  });
+}
+
+/** All provenance rows for a project's decisions, grouped by decision id (for the review queue UI). */
+export async function listProvenancesForProject(
+  orgId: string,
+  projectId: string,
+): Promise<Record<string, Array<{ source: string; externalId: string | null; url: string | null; evidence: unknown; confidence: number | null }>>> {
+  return withOrg(orgId, async (tx) => {
+    const ds = await tx.select({ id: decisions.id }).from(decisions).where(eq(decisions.projectId, projectId));
+    const ids = new Set(ds.map((d) => d.id));
+    const rows = await tx.select().from(decisionProvenances).where(eq(decisionProvenances.orgId, orgId));
+    const out: Record<string, Array<{ source: string; externalId: string | null; url: string | null; evidence: unknown; confidence: number | null }>> = {};
+    for (const r of rows) {
+      if (!ids.has(r.decisionId)) continue;
+      (out[r.decisionId] ??= []).push({ source: r.source, externalId: r.externalId, url: r.url, evidence: r.evidence, confidence: r.confidence });
+    }
+    return out;
+  });
+}
+
+export interface FileProposedInput {
+  projectId: string;
+  scopeKind: string; // surface | repo | topic | project | shared | contract
+  scopeRef: string;
+  ruleText: string;
+  decisionType?: string; // rule | architecture
+  provenance: unknown; // {source, connectionId, externalId, url, evidence[], extractorModel, confidence, decidedBy, decidedAt}
+  // idempotency + tuning audit keys (from the ingest funnel)
+  connectionId: string;
+  externalId: string;
+  contentHash: string;
+  confidence?: number; // 0..100
+}
+
+/**
+ * File a decision distilled from a human tool (Slack/Jira/Notion) as a **proposed** draft. It is
+ * `origin:"ingested"`, `status:"proposed"`, non-binding, and does NOT fan out — a human confirms it in
+ * the review queue before it can bind. Idempotent on (connectionId, externalId, contentHash): a
+ * re-seen unit returns the existing decision instead of minting a duplicate.
+ */
+export async function fileProposedDecision(
+  orgId: string,
+  input: FileProposedInput,
+): Promise<{ decisionId: string; deduped: boolean; fused: boolean; supersedes?: string }> {
+  const prov = (input.provenance ?? {}) as { source?: string; url?: string | null; evidence?: unknown };
+  const provRow = {
+    source: prov.source,
+    url: prov.url ?? null,
+    evidence: prov.evidence,
+    externalId: input.externalId,
+    confidence: input.confidence,
+  };
+  return withOrg(orgId, async (tx) => {
+    // Idempotency: a re-seen unit (same content) is never re-processed.
+    const seen = (
+      await tx
+        .select()
+        .from(ingestArtifacts)
+        .where(
+          and(
+            eq(ingestArtifacts.connectionId, input.connectionId),
+            eq(ingestArtifacts.externalId, input.externalId),
+            eq(ingestArtifacts.contentHash, input.contentHash),
+          ),
+        )
+        .limit(1)
+    )[0];
+    if (seen) return { decisionId: seen.decisionId ?? "", deduped: true, fused: false };
+
+    // Fusion + supersession: scan live decisions in the same scope.
+    const scopeMates = await tx
+      .select()
+      .from(decisions)
+      .where(and(eq(decisions.projectId, input.projectId), eq(decisions.scopeRef, input.scopeRef)));
+    let fuseInto: string | null = null;
+    let supersedes: string | undefined;
+    for (const m of scopeMates) {
+      if (m.status === "rejected" || m.status === "superseded") continue;
+      const v = (
+        await tx
+          .select()
+          .from(decisionVersions)
+          .where(and(eq(decisionVersions.decisionId, m.id), eq(decisionVersions.version, m.currentVersion)))
+          .limit(1)
+      )[0];
+      const sim = similar(input.ruleText, v?.ruleText ?? "");
+      if (sim >= 0.6) {
+        fuseInto = m.id;
+        break;
+      }
+      if (m.status === "binding" && sim < 0.4) supersedes = m.id; // different rule, same scope → likely supersession
+    }
+
+    if (fuseInto) {
+      // One decision, many provenances — attach this source instead of minting a duplicate.
+      await addProvenanceTx(tx, orgId, fuseInto, provRow);
+      await tx.insert(ingestArtifacts).values({
+        orgId,
+        connectionId: input.connectionId,
+        externalId: input.externalId,
+        contentHash: input.contentHash,
+        status: "fused",
+        confidence: input.confidence ?? null,
+        decisionId: fuseInto,
+      });
+      await writeAudit(tx, {
+        orgId,
+        projectId: input.projectId,
+        action: "decision.provenance_added",
+        entityKind: "decision",
+        entityId: fuseInto,
+        payload: { source: prov.source, externalId: input.externalId },
+      });
+      return { decisionId: fuseInto, deduped: false, fused: true };
+    }
+
+    const d = one(
+      await tx
+        .insert(decisions)
+        .values({
+          orgId,
+          projectId: input.projectId,
+          scopeKind: input.scopeKind,
+          scopeRef: input.scopeRef,
+          decisionType: input.decisionType ?? "rule",
+          currentVersion: 1,
+          status: "proposed",
+          origin: "ingested",
+        })
+        .returning(),
+    );
+    await tx.insert(decisionVersions).values({
+      orgId,
+      decisionId: d.id,
+      version: 1,
+      baseVersion: 0,
+      ruleText: input.ruleText,
+      provenance: supersedes ? { ...(input.provenance as object), supersedes } : (input.provenance ?? null),
+      status: "proposed",
+    });
+    await addProvenanceTx(tx, orgId, d.id, provRow);
+    await tx.insert(ingestArtifacts).values({
+      orgId,
+      connectionId: input.connectionId,
+      externalId: input.externalId,
+      contentHash: input.contentHash,
+      status: "proposed",
+      confidence: input.confidence ?? null,
+      decisionId: d.id,
+    });
+    await writeAudit(tx, {
+      orgId,
+      projectId: input.projectId,
+      action: "decision.proposed",
+      entityKind: "decision",
+      entityId: d.id,
+      entityVersion: 1,
+      payload: { scopeKind: input.scopeKind, scopeRef: input.scopeRef, origin: "ingested", status: "proposed", supersedes },
+    });
+    return { decisionId: d.id, deduped: false, fused: false, supersedes };
+  });
+}
+
+/**
+ * Confirm a proposed (ingested) decision: run the same impact/binding path as an agent-authored
+ * decision (own-area binds on assertion; cross-cutting stays `open` until acked and fans out). Optional
+ * `edits` overwrite the current version's rule text / scope before confirming.
+ */
+export async function confirmDecision(
+  orgId: string,
+  decisionId: string,
+  memberId: string,
+  edits?: { ruleText?: string; scopeKind?: string; scopeRef?: string },
+): Promise<{ status: string; impact: number }> {
+  return withOrg(orgId, async (tx) => {
+    const d = (await tx.select().from(decisions).where(eq(decisions.id, decisionId)).limit(1))[0];
+    if (!d) throw Object.assign(new Error("decision not found"), { statusCode: 404 });
+    if (d.status !== "proposed") throw conflict(`decision is ${d.status}, not proposed`);
+
+    // decision_versions is append-only, so edits are a new version, never an in-place UPDATE.
+    const cur = (
+      await tx
+        .select()
+        .from(decisionVersions)
+        .where(and(eq(decisionVersions.decisionId, decisionId), eq(decisionVersions.version, d.currentVersion)))
+        .limit(1)
+    )[0];
+    const scopeKind = edits?.scopeKind ?? d.scopeKind;
+    const scopeRef = edits?.scopeRef ?? d.scopeRef;
+    const ruleText = edits?.ruleText ?? cur?.ruleText ?? "";
+    const edited = Boolean(edits?.ruleText || edits?.scopeKind || edits?.scopeRef);
+
+    const impact = await impactForScopeTx(tx, d.projectId, scopeKind, scopeRef);
+    const needsAck = impact > 0;
+    const status = needsAck ? "open" : "binding";
+    let version = d.currentVersion;
+    if (edited) {
+      version = d.currentVersion + 1;
+      await tx.insert(decisionVersions).values({
+        orgId,
+        decisionId,
+        version,
+        baseVersion: d.currentVersion,
+        ruleText,
+        provenance: cur?.provenance ?? null,
+        status,
+        proposedBy: memberId,
+      });
+    }
+    await tx
+      .update(decisions)
+      .set({ scopeKind, scopeRef, status, impact, currentVersion: version })
+      .where(eq(decisions.id, decisionId));
+    await writeAudit(tx, {
+      orgId,
+      projectId: d.projectId,
+      actorMemberId: memberId,
+      action: "decision.confirmed",
+      entityKind: "decision",
+      entityId: decisionId,
+      entityVersion: version,
+      payload: { scopeKind, scopeRef, status, impact, origin: d.origin },
+    });
+    if (needsAck) {
+      await fanoutToProjectTx(tx, orgId, {
+        projectId: d.projectId,
+        refId: decisionId,
+        kind: "decision",
+        senderMemberId: memberId,
+        reason: { scopeRef, ruleText, impact },
+      });
+    }
+    return { status, impact };
+  });
+}
+
+/** Reject a proposed (ingested) decision — a human declined it. It never binds. */
+export async function rejectDecision(
+  orgId: string,
+  decisionId: string,
+  memberId: string,
+): Promise<{ status: string }> {
+  return withOrg(orgId, async (tx) => {
+    const d = (await tx.select().from(decisions).where(eq(decisions.id, decisionId)).limit(1))[0];
+    if (!d) throw Object.assign(new Error("decision not found"), { statusCode: 404 });
+    // decision_versions is append-only; the live status lives on decisions.status.
+    await tx.update(decisions).set({ status: "rejected" }).where(eq(decisions.id, decisionId));
+    await writeAudit(tx, {
+      orgId,
+      projectId: d.projectId,
+      actorMemberId: memberId,
+      action: "decision.rejected",
+      entityKind: "decision",
+      entityId: decisionId,
+      entityVersion: d.currentVersion,
+    });
+    return { status: "rejected" };
+  });
+}
+
 export async function listDecisions(
   orgId: string,
   projectId: string,
   scopeRef?: string,
+  opts?: { status?: string; origin?: string },
 ): Promise<
   Array<{
     id: string;
     scopeKind: string;
     scopeRef: string;
     status: string;
+    origin: string;
     version: number;
     ruleText: string;
+    provenance: unknown;
     decisionType: string;
     impact: number;
+    createdAt: Date;
   }>
 > {
   return withOrg(orgId, async (tx) => {
@@ -218,6 +562,8 @@ export async function listDecisions(
     const out = [];
     for (const d of ds) {
       if (scopeRef && d.scopeRef !== scopeRef) continue;
+      if (opts?.status && d.status !== opts.status) continue;
+      if (opts?.origin && d.origin !== opts.origin) continue;
       const v = (
         await tx
           .select()
@@ -230,10 +576,13 @@ export async function listDecisions(
         scopeKind: d.scopeKind,
         scopeRef: d.scopeRef,
         status: d.status,
+        origin: d.origin,
         version: d.currentVersion,
         ruleText: v?.ruleText ?? "",
+        provenance: v?.provenance ?? null,
         decisionType: d.decisionType,
         impact: d.impact,
+        createdAt: d.createdAt,
       });
     }
     return out;

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@lockstep/ingest",
+  "version": "0.1.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "lockstep-ingest": "dist/index.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "start": "node dist/index.js",
+    "test": "find src -name '*.test.ts' | xargs node --import tsx --test --test-force-exit",
+    "coverage": "find src -name '*.test.ts' | xargs node --import tsx --test --test-force-exit --experimental-test-coverage --test-coverage-exclude='**/*.test.ts' --test-coverage-exclude='**/index.ts' --test-coverage-exclude='**/client.ts' --test-coverage-exclude='**/connectors/ComposioConnector.ts' --test-coverage-exclude='**/connectors/NangoConnector.ts' --test-coverage-exclude='**/distill/llm.ts' --test-coverage-exclude='**/distill/extract.ts' --test-coverage-exclude='**/distill/recall.ts' --test-coverage-exclude='**/eval/**'"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "latest"
+  },
+  "optionalDependencies": {
+    "@composio/core": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/ingest/src/client.ts
+++ b/packages/ingest/src/client.ts
@@ -1,0 +1,70 @@
+/** Thin authed HTTP client to core's /ingest/* worker endpoints (service-token auth). */
+
+export interface WorkSource {
+  sourceRef: string;
+  sourceName: string | null;
+  cursor: string | null;
+}
+export interface WorkItem {
+  orgId: string;
+  projectId: string;
+  connectionId: string;
+  tool: string;
+  entity: string;
+  connectedAccountId: string | null;
+  sources: WorkSource[];
+}
+
+export interface ProposedItem {
+  orgId: string;
+  projectId: string;
+  scopeKind: string;
+  scopeRef: string;
+  ruleText: string;
+  decisionType?: string;
+  provenance: unknown;
+  connectionId: string;
+  externalId: string;
+  contentHash: string;
+  confidence?: number; // 0..100
+}
+
+export class LockstepClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token: string,
+  ) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+  }
+
+  private async req<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        "content-type": "application/json",
+        "x-lockstep-ingest-token": this.token,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`${method} ${path} → ${res.status} ${await res.text()}`);
+    return (await res.json()) as T;
+  }
+
+  async getWork(): Promise<WorkItem[]> {
+    const r = await this.req<{ work: WorkItem[] }>("GET", "/ingest/work");
+    return r.work;
+  }
+
+  async postProposed(items: ProposedItem[]): Promise<{ filed: number; deduped: number }> {
+    if (items.length === 0) return { filed: 0, deduped: 0 };
+    return this.req("POST", "/ingest/proposed-decisions", { items });
+  }
+
+  async setWatermark(orgId: string, connectionId: string, sourceRef: string, cursor: string): Promise<void> {
+    await this.req("POST", "/ingest/watermark", { orgId, connectionId, sourceRef, cursor });
+  }
+
+  async finalizeConnection(connectionId: string, connectedAccountId: string): Promise<void> {
+    await this.req("POST", `/ingest/connections/${connectionId}/finalize`, { connectedAccountId });
+  }
+}

--- a/packages/ingest/src/connectors/ComposioConnector.ts
+++ b/packages/ingest/src/connectors/ComposioConnector.ts
@@ -1,0 +1,240 @@
+import type { SourceConnector, Unit, Channel } from "./SourceConnector.js";
+
+export type Tool = "slack" | "jira" | "notion" | "confluence";
+
+/**
+ * Composio-backed connector for every human-coordination source. One class, per-tool routing — the
+ * distillation funnel is source-agnostic (it just consumes Units). Verified Composio slugs:
+ *   Slack:      SLACK_FIND_CHANNELS, SLACK_FETCH_CONVERSATION_HISTORY, SLACK_FETCH_MESSAGE_THREAD_FROM_A_CONVERSATION
+ *   Jira:       JIRA_GET_ALL_PROJECTS, JIRA_SEARCH_ISSUES (JQL)
+ *   Notion:     NOTION_SEARCH_NOTION_PAGE, NOTION_QUERY_DATABASE, NOTION_GET_PAGE_MARKDOWN
+ *   Confluence: CONFLUENCE_SEARCH, CONFLUENCE_GET_PAGE_BY_ID (best-effort; verify against installed SDK)
+ *
+ * The @composio/core SDK loads via a computed dynamic import so this file typechecks / the worker builds
+ * even without the package (CI runs only StubConnector). `exec()` is the one place the SDK call shape
+ * lives; it's exercised by the live test, not CI. Composio holds the OAuth token; we never see it.
+ */
+export class ComposioConnector implements SourceConnector {
+  private client: unknown;
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly entity: string,
+    private readonly tool: Tool = "slack",
+    private readonly defaultWindowDays = 7,
+  ) {}
+
+  private async getClient(): Promise<Record<string, unknown>> {
+    if (!this.client) {
+      const spec = "@composio/core";
+      const mod: Record<string, unknown> = await import(spec);
+      const Composio = mod.Composio as new (opts: { apiKey: string }) => unknown;
+      this.client = new Composio({ apiKey: this.apiKey });
+    }
+    return this.client as Record<string, unknown>;
+  }
+
+  private async exec(slug: string, input: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const client = (await this.getClient()) as { tools: { execute: (args: unknown) => Promise<unknown> } };
+    const res = (await client.tools.execute({
+      entity: this.entity,
+      app: this.tool,
+      tool: slug,
+      input,
+    })) as { data?: Record<string, unknown>; successful?: boolean; error?: string };
+    if (res && res.successful === false) throw new Error(`composio ${slug} failed: ${res.error ?? "unknown"}`);
+    return (res?.data ?? {}) as Record<string, unknown>;
+  }
+
+  private sinceEpoch(cursor: string | null): number {
+    if (cursor && /^\d+(\.\d+)?$/.test(cursor)) return Math.floor(Number(cursor));
+    return Math.floor(Date.now() / 1000) - this.defaultWindowDays * 86400;
+  }
+  private sinceIso(cursor: string | null): string {
+    if (cursor && cursor.includes("-")) return cursor;
+    return new Date((Math.floor(Date.now() / 1000) - this.defaultWindowDays * 86400) * 1000).toISOString();
+  }
+
+  /* ── OAuth (control-plane) ── */
+
+  async initiate(): Promise<{ redirectUrl: string; connectedAccountId: string }> {
+    const client = (await this.getClient()) as {
+      getEntity?: (id: string) => Promise<{ initiateConnection: (o: unknown) => Promise<unknown> }>;
+      connectedAccounts?: { initiate: (o: unknown) => Promise<unknown> };
+    };
+    if (client.getEntity) {
+      const entity = await client.getEntity(this.entity);
+      const conn = (await entity.initiateConnection({ appName: this.tool, authScheme: "OAUTH2" })) as {
+        redirectUrl?: string;
+        redirect_url?: string;
+        connectedAccountId?: string;
+        id?: string;
+      };
+      return {
+        redirectUrl: conn.redirectUrl ?? conn.redirect_url ?? "",
+        connectedAccountId: conn.connectedAccountId ?? conn.id ?? "",
+      };
+    }
+    const conn = (await client.connectedAccounts!.initiate({ entityId: this.entity, app: this.tool })) as {
+      redirectUrl?: string;
+      connectedAccountId?: string;
+      id?: string;
+    };
+    return { redirectUrl: conn.redirectUrl ?? "", connectedAccountId: conn.connectedAccountId ?? conn.id ?? "" };
+  }
+
+  async isActive(connectedAccountId: string): Promise<boolean> {
+    const client = (await this.getClient()) as {
+      connectedAccounts?: { get: (o: unknown) => Promise<{ status?: string }> };
+    };
+    if (!client.connectedAccounts?.get) return true;
+    const acc = await client.connectedAccounts.get({ connectedAccountId });
+    return (acc.status ?? "").toUpperCase() === "ACTIVE";
+  }
+
+  /* ── Sources (channels / projects / spaces / databases) ── */
+
+  async listChannels(): Promise<Channel[]> {
+    switch (this.tool) {
+      case "slack": {
+        const d = await this.exec("SLACK_FIND_CHANNELS", { limit: 200, exclude_archived: true });
+        return arr(d.channels ?? d.results).flatMap((c) => (c.id ? [{ id: String(c.id), name: str(c.name) || String(c.id) }] : []));
+      }
+      case "jira": {
+        const d = await this.exec("JIRA_GET_ALL_PROJECTS", {});
+        return arr(d.projects ?? d.values ?? d).flatMap((p) => (p.key ? [{ id: String(p.key), name: str(p.name) || String(p.key) }] : []));
+      }
+      case "notion": {
+        const d = await this.exec("NOTION_SEARCH_NOTION_PAGE", { filter_value: "database", page_size: 100 });
+        return arr(d.results).flatMap((r) => (r.id ? [{ id: String(r.id), name: notionTitle(r) }] : []));
+      }
+      case "confluence": {
+        const d = await this.exec("CONFLUENCE_GET_SPACES", { limit: 100 });
+        return arr(d.results ?? d.spaces).flatMap((s) => (s.key || s.id ? [{ id: String(s.key ?? s.id), name: str(s.name) }] : []));
+      }
+    }
+  }
+
+  /* ── Units ── */
+
+  async listUnitsSince(sourceRef: string, sinceCursor: string | null): Promise<Unit[]> {
+    switch (this.tool) {
+      case "slack":
+        return this.slackUnits(sourceRef, sinceCursor);
+      case "jira":
+        return this.jiraUnits(sourceRef, sinceCursor);
+      case "notion":
+        return this.notionUnits(sourceRef, sinceCursor);
+      case "confluence":
+        return this.confluenceUnits(sourceRef, sinceCursor);
+    }
+  }
+
+  private async slackUnits(channel: string, cursor: string | null): Promise<Unit[]> {
+    const hist = await this.exec("SLACK_FETCH_CONVERSATION_HISTORY", {
+      channel,
+      oldest: String(this.sinceEpoch(cursor)),
+      limit: 200,
+    });
+    const units: Unit[] = [];
+    for (const m of arr(hist.messages)) {
+      const ts = str(m.ts);
+      if (!ts || (m.thread_ts && m.thread_ts !== m.ts)) continue;
+      const lines = [renderSlack(m)];
+      const authors = new Set<string>(author(m));
+      if (Number(m.reply_count ?? 0) > 0) {
+        const thread = await this.exec("SLACK_FETCH_MESSAGE_THREAD_FROM_A_CONVERSATION", { channel, ts });
+        for (const r of arr(thread.messages)) {
+          if (str(r.ts) === ts) continue;
+          lines.push(renderSlack(r));
+          author(r).forEach((a) => authors.add(a));
+        }
+      }
+      units.push({ externalId: `${channel}/${ts}`, sourceRef: channel, ts, text: lines.join("\n"), authors: [...authors], permalink: str(m.permalink) || undefined });
+    }
+    return units;
+  }
+
+  private async jiraUnits(projectKey: string, cursor: string | null): Promise<Unit[]> {
+    const since = this.sinceIso(cursor).slice(0, 10); // JQL date
+    const jql = `project = "${projectKey}" AND updated >= "${since}" ORDER BY updated DESC`;
+    const d = await this.exec("JIRA_SEARCH_ISSUES", { jql, maxResults: 100, fields: ["summary", "description", "comment", "updated"] });
+    const units: Unit[] = [];
+    for (const issue of arr(d.issues)) {
+      const key = str(issue.key);
+      const f = (issue.fields ?? {}) as Record<string, unknown>;
+      const comments = arr((f.comment as Record<string, unknown>)?.comments).map((c) => `${author(c)[0] ?? "?"}: ${plain(c.body)}`);
+      const text = `${key} ${str(f.summary)}\n${plain(f.description)}\n${comments.join("\n")}`.trim();
+      const ts = str(f.updated) || new Date().toISOString();
+      units.push({ externalId: `${projectKey}/${key}`, sourceRef: projectKey, ts, text, authors: comments.length ? [] : [], permalink: str(issue.self) || undefined });
+    }
+    return units;
+  }
+
+  private async notionUnits(sourceRef: string, cursor: string | null): Promise<Unit[]> {
+    const isDb = /^[0-9a-f]{8}-?[0-9a-f]{4}/i.test(sourceRef);
+    const listing = isDb
+      ? await this.exec("NOTION_QUERY_DATABASE", { database_id: sourceRef, page_size: 100 })
+      : await this.exec("NOTION_SEARCH_NOTION_PAGE", { query: sourceRef, filter_value: "page", page_size: 100 });
+    const since = this.sinceIso(cursor);
+    const units: Unit[] = [];
+    for (const page of arr(listing.results)) {
+      const pageId = str(page.id);
+      const edited = str(page.last_edited_time) || since;
+      if (edited < since) continue;
+      const md = await this.exec("NOTION_GET_PAGE_MARKDOWN", { page_id: pageId });
+      const text = `${notionTitle(page)}\n${str(md.markdown ?? md.content ?? md.text)}`.trim();
+      units.push({ externalId: `${sourceRef}/${pageId}`, sourceRef, ts: edited, text, authors: [], permalink: str(page.url) || undefined });
+    }
+    return units;
+  }
+
+  private async confluenceUnits(spaceKey: string, cursor: string | null): Promise<Unit[]> {
+    const since = this.sinceIso(cursor).slice(0, 10);
+    const d = await this.exec("CONFLUENCE_SEARCH", { cql: `space = "${spaceKey}" AND lastmodified >= "${since}"`, limit: 100 });
+    const units: Unit[] = [];
+    for (const r of arr(d.results ?? d.pages)) {
+      const id = str(r.id ?? (r.content as Record<string, unknown>)?.id);
+      if (!id) continue;
+      const page = await this.exec("CONFLUENCE_GET_PAGE_BY_ID", { id, expand: "body.storage,version" });
+      const body = plain((page.body as Record<string, unknown>)?.storage ?? page.body);
+      const ts = str((page.version as Record<string, unknown>)?.when) || this.sinceIso(cursor);
+      units.push({ externalId: `${spaceKey}/${id}`, sourceRef: spaceKey, ts, text: `${str(page.title)}\n${body}`.trim(), authors: [], permalink: str(page._links && (page._links as Record<string, unknown>).webui) || undefined });
+    }
+    return units;
+  }
+}
+
+/* helpers — defensive against varying Composio response shapes */
+function arr(v: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(v) ? (v as Array<Record<string, unknown>>) : [];
+}
+function str(v: unknown): string {
+  return typeof v === "string" ? v : v == null ? "" : String(v);
+}
+function author(m: Record<string, unknown>): string[] {
+  const a = m.user ?? m.username ?? m.author ?? (m.author as Record<string, unknown>)?.displayName ?? m.bot_id;
+  return a ? [str(a)] : [];
+}
+function renderSlack(m: Record<string, unknown>): string {
+  return `${str(m.user ?? m.username ?? "unknown")}: ${str(m.text)}`;
+}
+function plain(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (v && typeof v === "object") {
+    const o = v as Record<string, unknown>;
+    if (typeof o.value === "string") return o.value; // confluence body.storage.value
+    return JSON.stringify(v).slice(0, 4000); // ADF / rich text fallback
+  }
+  return "";
+}
+function notionTitle(page: Record<string, unknown>): string {
+  const props = page.properties as Record<string, unknown> | undefined;
+  if (props) {
+    for (const p of Object.values(props)) {
+      const t = (p as Record<string, unknown>)?.title as Array<{ plain_text?: string }> | undefined;
+      if (Array.isArray(t) && t[0]?.plain_text) return t.map((x) => x.plain_text).join("");
+    }
+  }
+  return str(page.title) || "(untitled)";
+}

--- a/packages/ingest/src/connectors/NangoConnector.ts
+++ b/packages/ingest/src/connectors/NangoConnector.ts
@@ -1,0 +1,65 @@
+import type { SourceConnector, Unit, Channel } from "./SourceConnector.js";
+
+/**
+ * Self-hosted / data-residency alternative to Composio, behind the same SourceConnector interface
+ * (the Phase-4 swap). Nango proxies provider APIs so tokens stay in infrastructure you run. This impl
+ * proxies the Slack Web API through Nango's proxy endpoint; other providers follow the same shape.
+ *
+ * Env: NANGO_SECRET_KEY (+ base URL for self-host). Per-connection: connectionId + providerConfigKey.
+ * Verified against Nango's proxy contract (Authorization + Connection-Id + Provider-Config-Key headers).
+ */
+export class NangoConnector implements SourceConnector {
+  constructor(
+    private readonly secretKey: string,
+    private readonly connectionId: string,
+    private readonly providerConfigKey = "slack",
+    private readonly baseUrl = process.env.NANGO_HOST || "https://api.nango.dev",
+    private readonly windowDays = 7,
+  ) {}
+
+  private async proxy(path: string): Promise<Record<string, unknown>> {
+    const res = await fetch(`${this.baseUrl.replace(/\/+$/, "")}/proxy${path}`, {
+      headers: {
+        Authorization: `Bearer ${this.secretKey}`,
+        "Connection-Id": this.connectionId,
+        "Provider-Config-Key": this.providerConfigKey,
+      },
+    });
+    if (!res.ok) throw new Error(`nango proxy ${path} → ${res.status} ${await res.text()}`);
+    const body = (await res.json()) as { data?: Record<string, unknown> } & Record<string, unknown>;
+    // Nango returns the provider payload (sometimes wrapped in {data}).
+    return (body.data ?? body) as Record<string, unknown>;
+  }
+
+  async listChannels(): Promise<Channel[]> {
+    const d = await this.proxy(`/api/conversations.list?limit=200&exclude_archived=true`);
+    const chans = (d.channels ?? []) as Array<{ id?: string; name?: string }>;
+    return chans.flatMap((c) => (c.id ? [{ id: c.id, name: c.name ?? c.id }] : []));
+  }
+
+  async listUnitsSince(channel: string, sinceCursor: string | null): Promise<Unit[]> {
+    const oldest =
+      sinceCursor && /^\d+(\.\d+)?$/.test(sinceCursor)
+        ? sinceCursor
+        : String(Math.floor(Date.now() / 1000) - this.windowDays * 86400);
+    const hist = await this.proxy(`/api/conversations.history?channel=${channel}&oldest=${oldest}&limit=200`);
+    const messages = (hist.messages ?? []) as Array<Record<string, unknown>>;
+    const units: Unit[] = [];
+    for (const m of messages) {
+      const ts = String(m.ts ?? "");
+      if (!ts || (m.thread_ts && m.thread_ts !== m.ts)) continue;
+      const lines = [`${String(m.user ?? "unknown")}: ${String(m.text ?? "")}`];
+      const authors = new Set<string>(m.user ? [String(m.user)] : []);
+      if (Number(m.reply_count ?? 0) > 0) {
+        const thread = await this.proxy(`/api/conversations.replies?channel=${channel}&ts=${ts}`);
+        for (const r of (thread.messages ?? []) as Array<Record<string, unknown>>) {
+          if (String(r.ts) === ts) continue;
+          lines.push(`${String(r.user ?? "unknown")}: ${String(r.text ?? "")}`);
+          if (r.user) authors.add(String(r.user));
+        }
+      }
+      units.push({ externalId: `${channel}/${ts}`, sourceRef: channel, ts, text: lines.join("\n"), authors: [...authors] });
+    }
+    return units;
+  }
+}

--- a/packages/ingest/src/connectors/SourceConnector.ts
+++ b/packages/ingest/src/connectors/SourceConnector.ts
@@ -1,0 +1,33 @@
+/**
+ * The seam between Lockstep and a human-coordination tool. Composio backs it today (ComposioConnector);
+ * a self-hosted Nango backend can implement the same interface later (Phase 4) without touching the
+ * distillation funnel. StubConnector implements it for deterministic tests.
+ */
+
+/** A conversation unit — the atom the funnel distills. A Slack thread (root + replies) is one unit. */
+export interface Unit {
+  /** Stable id within a source, e.g. `${channelId}/${threadTs}`. Idempotency key with contentHash. */
+  externalId: string;
+  sourceRef: string; // the allowlisted source this came from (channel id)
+  sourceName?: string; // #channel label
+  /** Full concatenated text of the unit (root message + replies), author-attributed. */
+  text: string;
+  authors: string[]; // display handles/ids that participated
+  ts: string; // root timestamp — the watermark cursor advances past the max ts seen
+  permalink?: string; // deep link back to the source, for provenance
+}
+
+export interface Channel {
+  id: string;
+  name: string;
+}
+
+export interface SourceConnector {
+  /** List channels/projects/spaces available to this connection (helps the admin pick allowlist entries). */
+  listChannels(): Promise<Channel[]>;
+  /**
+   * Return conversation units in one allowlisted source that are newer than `sinceCursor`
+   * (null = the connector's default window, e.g. last 7 days). Newest-inclusive.
+   */
+  listUnitsSince(sourceRef: string, sinceCursor: string | null): Promise<Unit[]>;
+}

--- a/packages/ingest/src/connectors/StubConnector.ts
+++ b/packages/ingest/src/connectors/StubConnector.ts
@@ -1,0 +1,40 @@
+import type { SourceConnector, Unit, Channel } from "./SourceConnector.js";
+
+/** Canned data for deterministic tests and local demos — no network, no Composio, no Slack app. */
+export class StubConnector implements SourceConnector {
+  constructor(private readonly units: Unit[] = StubConnector.sample()) {}
+
+  async listChannels(): Promise<Channel[]> {
+    return [{ id: "C_STUB", name: "eng-decisions" }];
+  }
+
+  async listUnitsSince(sourceRef: string, _sinceCursor: string | null): Promise<Unit[]> {
+    return this.units.filter((u) => u.sourceRef === sourceRef);
+  }
+
+  static sample(): Unit[] {
+    return [
+      {
+        externalId: "C_STUB/1699000001.0001",
+        sourceRef: "C_STUB",
+        sourceName: "eng-decisions",
+        ts: "1699000001.0001",
+        authors: ["@alice", "@bob"],
+        permalink: "https://example.slack.com/archives/C_STUB/p16990000010001",
+        text:
+          "@alice: should auth tokens be JWT or server-side sessions?\n" +
+          "@bob: JWT keeps us stateless across services. I say JWT, 15-min expiry.\n" +
+          "@alice: agreed — let's lock it: JWT with 15-minute expiry, refresh via /auth/session. Shipping it.",
+      },
+      {
+        externalId: "C_STUB/1699000002.0002",
+        sourceRef: "C_STUB",
+        sourceName: "eng-decisions",
+        ts: "1699000002.0002",
+        authors: ["@carol"],
+        permalink: "https://example.slack.com/archives/C_STUB/p16990000020002",
+        text: "@carol: anyone grabbing lunch? the cafeteria line is huge today lol",
+      },
+    ];
+  }
+}

--- a/packages/ingest/src/connectors/stub.test.ts
+++ b/packages/ingest/src/connectors/stub.test.ts
@@ -1,0 +1,25 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { StubConnector } from "./StubConnector.js";
+
+test("StubConnector: lists a channel and returns its canned units", async () => {
+  const c = new StubConnector();
+  const chans = await c.listChannels();
+  assert.equal(chans.length, 1);
+  assert.equal(chans[0]!.id, "C_STUB");
+
+  const units = await c.listUnitsSince("C_STUB", null);
+  assert.ok(units.length >= 2);
+  assert.ok(units.every((u) => u.sourceRef === "C_STUB"));
+  assert.ok(units.some((u) => u.text.includes("JWT")), "includes the decision thread");
+});
+
+test("StubConnector: unknown source yields no units; custom units are respected", async () => {
+  assert.deepEqual(await new StubConnector().listUnitsSince("nope", null), []);
+  const custom = new StubConnector([
+    { externalId: "X/1", sourceRef: "X", ts: "1.0", text: "hi", authors: [] },
+  ]);
+  const units = await custom.listUnitsSince("X", null);
+  assert.equal(units.length, 1);
+  assert.equal(units[0]!.externalId, "X/1");
+});

--- a/packages/ingest/src/distill/extract.ts
+++ b/packages/ingest/src/distill/extract.ts
@@ -1,0 +1,97 @@
+import { anthropic, MODELS } from "./llm.js";
+import { RUBRIC_SYSTEM, EXTRACTION_SCHEMA, type Extraction } from "./rubric.js";
+
+const EMPTY: Extraction = {
+  is_decision: false,
+  decision_type: "none",
+  finality: "none",
+  rule_text: "",
+  rationale: "",
+  alternatives_considered: [],
+  decided_by: [],
+  scope_hint: "",
+  surface_candidates: [],
+  confidence: 0,
+  evidence: [],
+};
+
+/** Request params for one extraction — shared by the sync call and the Batch API path. */
+function buildParams(model: string, externalId: string, text: string): Record<string, unknown> {
+  return {
+    model,
+    max_tokens: 1024,
+    system: [{ type: "text", text: RUBRIC_SYSTEM, cache_control: { type: "ephemeral" } }],
+    output_config: { format: { type: "json_schema", schema: EXTRACTION_SCHEMA } },
+    messages: [{ role: "user", content: `Thread externalId: ${externalId}\n\n${text.slice(0, 12000)}` }],
+  };
+}
+
+function parseExtraction(content: Array<{ type: string; text?: string }>): Extraction {
+  const block = content.find((b) => b.type === "text");
+  if (!block?.text) return EMPTY;
+  try {
+    return { ...EMPTY, ...(JSON.parse(block.text) as Extraction) };
+  } catch {
+    return EMPTY;
+  }
+}
+
+async function callModel(model: string, externalId: string, text: string): Promise<Extraction> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const res: any = await anthropic().messages.create(buildParams(model, externalId, text) as any);
+  return parseExtraction(res.content);
+}
+
+/**
+ * Stage 2 (synchronous) — structured extraction (Sonnet), Opus re-check on borderline confidence.
+ * The rubric system block is prompt-cached so repeated threads reuse it at ~0.1x.
+ */
+export async function extract(externalId: string, text: string): Promise<Extraction> {
+  const first = await callModel(MODELS.extract, externalId, text);
+  if (first.is_decision && first.confidence >= 0.35 && first.confidence < 0.6) {
+    const second = await callModel(MODELS.recheck, externalId, text);
+    return second.confidence >= first.confidence ? second : first;
+  }
+  return first;
+}
+
+/**
+ * Stage 2 (batch) — the 50%-cost path for scheduled sweeps. Submits all survivors as one Message
+ * Batch, polls to completion, and returns extractions keyed by externalId. No Opus re-check in batch
+ * mode (a follow-up sync pass can re-check borderline items if desired).
+ */
+export async function extractBatch(
+  items: Array<{ externalId: string; text: string }>,
+  opts: { pollMs?: number; maxWaitMs?: number } = {},
+): Promise<Map<string, Extraction>> {
+  const out = new Map<string, Extraction>();
+  if (items.length === 0) return out;
+  const client = anthropic();
+  const idToExternal = new Map<string, string>();
+  const requests = items.map((it, i) => {
+    const custom_id = `u${i}`;
+    idToExternal.set(custom_id, it.externalId);
+    return { custom_id, params: buildParams(MODELS.extract, it.externalId, it.text) };
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const batch: any = await (client.messages.batches as any).create({ requests });
+  const pollMs = opts.pollMs ?? 5000;
+  const deadline = Date.now() + (opts.maxWaitMs ?? 60 * 60 * 1000);
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b: any = await (client.messages.batches as any).retrieve(batch.id);
+    if (b.processing_status === "ended") break;
+    if (Date.now() > deadline) throw new Error(`batch ${batch.id} did not finish before deadline`);
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  for await (const r of await (client.messages.batches as any).results(batch.id)) {
+    const ext = idToExternal.get(r.custom_id);
+    if (!ext) continue;
+    out.set(ext, r.result?.type === "succeeded" ? parseExtraction(r.result.message.content) : EMPTY);
+  }
+  return out;
+}

--- a/packages/ingest/src/distill/gate.test.ts
+++ b/packages/ingest/src/distill/gate.test.ts
@@ -1,0 +1,40 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { gate } from "./gate.js";
+import type { Extraction } from "./rubric.js";
+
+function ex(over: Partial<Extraction>): Extraction {
+  return {
+    is_decision: true,
+    decision_type: "rule",
+    finality: "agreed",
+    rule_text: "Auth tokens are JWT.",
+    rationale: "",
+    alternatives_considered: [],
+    decided_by: [],
+    scope_hint: "auth",
+    surface_candidates: [],
+    confidence: 0.9,
+    evidence: [{ externalId: "x", quote: "JWT it is" }],
+    ...over,
+  };
+}
+
+test("gate: agreed, confident, with evidence → propose", () => {
+  assert.equal(gate(ex({})), "propose");
+});
+
+test("gate: not a decision or low confidence → discard", () => {
+  assert.equal(gate(ex({ is_decision: false })), "discard");
+  assert.equal(gate(ex({ confidence: 0.3 })), "discard");
+});
+
+test("gate: decision but not agreed → question", () => {
+  assert.equal(gate(ex({ finality: "proposed" })), "question");
+  assert.equal(gate(ex({ finality: "reversed" })), "question");
+});
+
+test("gate: agreed but no rule text or no evidence → discard", () => {
+  assert.equal(gate(ex({ rule_text: "  " })), "discard");
+  assert.equal(gate(ex({ evidence: [] })), "discard");
+});

--- a/packages/ingest/src/distill/gate.ts
+++ b/packages/ingest/src/distill/gate.ts
@@ -1,0 +1,17 @@
+import type { Extraction } from "./rubric.js";
+
+export const CONFIDENCE_FLOOR = 0.5;
+
+export type GateAction = "propose" | "question" | "discard";
+
+/**
+ * Stage 5 — gate. A real, agreed, confident decision → propose (into the review queue). A decision that
+ * isn't yet agreed → question (Phase 2 files these as ledger Questions; for now logged + discarded).
+ * Everything else → discard. Nothing here binds — confirmation is a human step (Stage 7).
+ */
+export function gate(x: Extraction): GateAction {
+  if (!x.is_decision || x.confidence < CONFIDENCE_FLOOR) return "discard";
+  if (x.finality !== "agreed") return "question";
+  if (!x.rule_text.trim() || x.evidence.length === 0) return "discard";
+  return "propose";
+}

--- a/packages/ingest/src/distill/llm.ts
+++ b/packages/ingest/src/distill/llm.ts
@@ -1,0 +1,18 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+let client: Anthropic | null = null;
+
+/** Shared Anthropic client (reads ANTHROPIC_API_KEY from env). */
+export function anthropic(): Anthropic {
+  if (!client) {
+    if (!process.env.ANTHROPIC_API_KEY) throw new Error("ANTHROPIC_API_KEY is required for distillation");
+    client = new Anthropic();
+  }
+  return client;
+}
+
+export const MODELS = {
+  recall: "claude-haiku-4-5",
+  extract: "claude-sonnet-4-6",
+  recheck: "claude-opus-4-8",
+} as const;

--- a/packages/ingest/src/distill/recall.test.ts
+++ b/packages/ingest/src/distill/recall.test.ts
@@ -1,0 +1,23 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { keywordPrefilter, recall } from "./recall.js";
+
+test("keywordPrefilter: decision-language markers pass", () => {
+  assert.equal(keywordPrefilter("ok let's lock it: JWT 15 min"), true);
+  assert.equal(keywordPrefilter("going forward every write needs a key"), true);
+  assert.equal(keywordPrefilter("we decided to use Postgres"), true);
+});
+
+test("keywordPrefilter: chatter is dropped", () => {
+  assert.equal(keywordPrefilter("anyone want lunch? the line is huge"), false);
+  assert.equal(keywordPrefilter("deployed the hotfix, watching metrics"), false);
+});
+
+test("recall: prefilter miss short-circuits before any LLM call (no Haiku)", async () => {
+  // If this called Haiku it would throw (no ANTHROPIC_API_KEY in unit tests) — it must not.
+  assert.equal(await recall("just grabbing coffee", true), false);
+});
+
+test("recall: useHaiku=false returns the prefilter result", async () => {
+  assert.equal(await recall("we decided on quarterly billing", false), true);
+});

--- a/packages/ingest/src/distill/recall.ts
+++ b/packages/ingest/src/distill/recall.ts
@@ -1,0 +1,64 @@
+import { anthropic, MODELS } from "./llm.js";
+
+/**
+ * Stage 1 — cheap recall filter. Free keyword prefilter first; survivors get a Haiku binary check.
+ * Tuned for RECALL: better to pass a non-decision to the expensive extractor than to miss a real one.
+ */
+
+const MARKERS = [
+  "let's go with",
+  "lets go with",
+  "we decided",
+  "we've decided",
+  "decision:",
+  "final call",
+  "agreed",
+  "going forward",
+  "from now on",
+  "the plan is",
+  "we'll use",
+  "we will use",
+  "let's use",
+  "approved",
+  "sign off",
+  "signed off",
+  "locking",
+  "let's lock",
+  "lock it",
+  "standard",
+  "convention",
+  "rfc",
+  "adr",
+  "proposal",
+  "must",
+  "should always",
+  "no longer",
+  "instead of",
+];
+
+/** Free prefilter: does the text contain any decision-shaped language? */
+export function keywordPrefilter(text: string): boolean {
+  const t = text.toLowerCase();
+  return MARKERS.some((m) => t.includes(m));
+}
+
+/** Haiku binary "could this thread contain a durable, agreed decision?" — cheap, high-recall. */
+export async function haikuRecall(text: string): Promise<boolean> {
+  const res = await anthropic().messages.create({
+    model: MODELS.recall,
+    max_tokens: 5,
+    system:
+      "You are a fast filter. Answer ONLY 'yes' or 'no'. Say 'yes' if this chat thread MIGHT contain a durable, agreed engineering decision (a rule or architectural choice that shapes future work). When unsure, say 'yes'.",
+    messages: [{ role: "user", content: text.slice(0, 6000) }],
+  });
+  const block = res.content.find((b) => b.type === "text");
+  const answer = block && block.type === "text" ? block.text.toLowerCase() : "";
+  return answer.includes("yes");
+}
+
+/** Stage 1 combined: prefilter → Haiku. Returns whether to send the unit to extraction. */
+export async function recall(text: string, useHaiku = true): Promise<boolean> {
+  if (!keywordPrefilter(text)) return false;
+  if (!useHaiku) return true;
+  return haikuRecall(text);
+}

--- a/packages/ingest/src/distill/rubric.ts
+++ b/packages/ingest/src/distill/rubric.ts
@@ -1,0 +1,81 @@
+/** The Part-A.1 decision rubric + the forced-JSON extraction schema. Constant → prompt-cacheable. */
+
+export interface Evidence {
+  externalId: string;
+  quote: string;
+}
+
+export interface Extraction {
+  is_decision: boolean;
+  decision_type: "rule" | "architecture" | "none";
+  finality: "agreed" | "proposed" | "reversed" | "superseded" | "none";
+  rule_text: string;
+  rationale: string;
+  alternatives_considered: string[];
+  decided_by: string[];
+  scope_hint: string;
+  surface_candidates: string[];
+  confidence: number; // 0..1
+  evidence: Evidence[];
+}
+
+export const RUBRIC_SYSTEM = `You extract durable engineering DECISIONS from workplace chat threads.
+
+A message thread yields a decision ONLY if it passes all four tests:
+- DURABILITY: it constrains FUTURE work beyond the task at hand (a rule or architectural choice), not a one-off action.
+- AGREEMENT: it was actually CONCLUDED, not still being debated.
+- AGENCY: it was a real CHOICE among alternatives, not a mere statement of fact or a status update.
+- SPECIFICITY: it can be restated as ONE imperative rule.
+
+If any test fails, is_decision=false. Examples of NON-decisions: casual chatter, questions still open,
+status updates, one-off task assignments, venting, scheduling.
+
+Return STRICT JSON matching the schema. Rules:
+- rule_text: a single durable imperative sentence (e.g. "Auth tokens are JWT with 15-minute expiry.").
+- finality: "agreed" only if the thread shows the team concluded it; otherwise "proposed"/"reversed"/"superseded"/"none".
+- decided_by: the handles that assented.
+- scope_hint: the area it governs (e.g. "authentication", "billing"). Free text.
+- surface_candidates: any code interfaces referenced (HTTP routes, gRPC methods, GraphQL fields, packages), else [].
+- evidence: 1-3 VERBATIM quotes copied exactly from the thread that establish the decision. Never paraphrase.
+- confidence: 0..1, your calibrated probability that this is a real, agreed, durable decision.
+- If is_decision=false, still return the object with empty strings/arrays and confidence for "is a decision".`;
+
+/** JSON Schema for output_config.format (structured outputs). All props required; additionalProperties:false. */
+export const EXTRACTION_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "is_decision",
+    "decision_type",
+    "finality",
+    "rule_text",
+    "rationale",
+    "alternatives_considered",
+    "decided_by",
+    "scope_hint",
+    "surface_candidates",
+    "confidence",
+    "evidence",
+  ],
+  properties: {
+    is_decision: { type: "boolean" },
+    decision_type: { type: "string", enum: ["rule", "architecture", "none"] },
+    finality: { type: "string", enum: ["agreed", "proposed", "reversed", "superseded", "none"] },
+    rule_text: { type: "string" },
+    rationale: { type: "string" },
+    alternatives_considered: { type: "array", items: { type: "string" } },
+    decided_by: { type: "array", items: { type: "string" } },
+    scope_hint: { type: "string" },
+    surface_candidates: { type: "array", items: { type: "string" } },
+    confidence: { type: "number" },
+    evidence: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["externalId", "quote"],
+        properties: { externalId: { type: "string" }, quote: { type: "string" } },
+      },
+    },
+  },
+} as const;

--- a/packages/ingest/src/distill/scope.test.ts
+++ b/packages/ingest/src/distill/scope.test.ts
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { canonicalizeSurface, resolveScope } from "./scope.js";
+
+test("canonicalizeSurface: HTTP method + path → http: canonical", () => {
+  assert.equal(canonicalizeSurface("POST /auth/session"), "http:POST /auth/session");
+  assert.equal(canonicalizeSurface("get /orders"), "http:GET /orders");
+});
+
+test("canonicalizeSurface: path params and route groups normalized", () => {
+  assert.equal(canonicalizeSurface("GET /users/{id}"), "http:GET /users/:id");
+  assert.equal(canonicalizeSurface("GET /(auth)/me"), "http:GET /me");
+  assert.equal(canonicalizeSurface("POST /orders/"), "http:POST /orders");
+});
+
+test("canonicalizeSurface: proto and gql", () => {
+  assert.equal(canonicalizeSurface("billing.v1.Billing/Charge"), "proto:billing.v1.Billing/Charge");
+  assert.equal(canonicalizeSurface("Mutation.login"), "gql:Mutation.login");
+});
+
+test("canonicalizeSurface: bare path assumes ANY; junk returns null", () => {
+  assert.equal(canonicalizeSurface("/webhooks/stripe"), "http:ANY /webhooks/stripe");
+  assert.equal(canonicalizeSurface("just some words"), null);
+  assert.equal(canonicalizeSurface(""), null);
+});
+
+test("resolveScope: first canonicalizable surface wins", () => {
+  const s = resolveScope(["not a surface", "POST /auth/session"], "authentication");
+  assert.deepEqual(s, { scopeKind: "surface", scopeRef: "http:POST /auth/session" });
+});
+
+test("resolveScope: no surface → topic from hint (slugified)", () => {
+  assert.deepEqual(resolveScope([], "Billing Process"), { scopeKind: "topic", scopeRef: "topic:billing-process" });
+  assert.deepEqual(resolveScope([], ""), { scopeKind: "topic", scopeRef: "topic:general" });
+});

--- a/packages/ingest/src/distill/scope.ts
+++ b/packages/ingest/src/distill/scope.ts
@@ -1,0 +1,47 @@
+/**
+ * Stage 3 — scope resolution. Try to canonicalize a referenced code surface into the same grammar the
+ * v1 usage graph uses (http:/proto:/gql:), so an ingested decision can inherit real blast-radius impact.
+ * No code surface → land on a topic scope, impact 0 ("unscoped", honest) until the org-graph ships.
+ * Mirrors the canonical forms produced by packages/cli/src/capture/surface.ts.
+ */
+
+export interface Scope {
+  scopeKind: "surface" | "topic";
+  scopeRef: string;
+}
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "ANY"];
+
+function normalizePath(p: string): string {
+  return p
+    .replace(/\{(\w+)\}/g, ":$1") // {id} → :id
+    .replace(/\/\((\w+)\)/g, "") // strip route groups /(auth)
+    .replace(/\/+$/, "") || "/";
+}
+
+/** Turn one free-text surface candidate into a canonical surface id, or null if it isn't one. */
+export function canonicalizeSurface(candidate: string): string | null {
+  const c = candidate.trim();
+  // proto: pkg.Service/Rpc
+  if (/^[\w.]+\/[A-Za-z]\w*$/.test(c) && c.includes(".")) return `proto:${c}`;
+  // gql: Root.field
+  if (/^(Query|Mutation|Subscription)\.[A-Za-z]\w*$/.test(c)) return `gql:${c}`;
+  // http: METHOD /path
+  const m = c.match(/^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|ANY)\s+(\/\S*)$/i);
+  if (m) {
+    const method = m[1]!.toUpperCase();
+    if (HTTP_METHODS.includes(method)) return `http:${method} ${normalizePath(m[2]!)}`;
+  }
+  // bare path with no method → assume ANY
+  if (/^\/\S+$/.test(c)) return `http:ANY ${normalizePath(c)}`;
+  return null;
+}
+
+export function resolveScope(surfaceCandidates: string[], scopeHint: string): Scope {
+  for (const cand of surfaceCandidates) {
+    const canon = canonicalizeSurface(cand);
+    if (canon) return { scopeKind: "surface", scopeRef: canon };
+  }
+  const topic = (scopeHint || "general").toLowerCase().trim().replace(/\s+/g, "-");
+  return { scopeKind: "topic", scopeRef: `topic:${topic}` };
+}

--- a/packages/ingest/src/eval/golden.ts
+++ b/packages/ingest/src/eval/golden.ts
@@ -1,0 +1,60 @@
+/** Hand-labeled golden set for the extraction funnel (A.7). Grow this from review-queue rejects/edits. */
+export interface GoldenExample {
+  id: string;
+  text: string;
+  label: "decision" | "not";
+}
+
+export const GOLDEN: GoldenExample[] = [
+  {
+    id: "auth-jwt",
+    label: "decision",
+    text:
+      "@alice: JWT or server-side sessions for auth?\n@bob: JWT keeps us stateless.\n@alice: agreed — locking it: JWT, 15-minute expiry, refresh via /auth/session. shipping it.",
+  },
+  {
+    id: "bill-quarterly",
+    label: "decision",
+    text: "@carol: finance wants quarterly billing.\n@dave: fine by eng.\n@carol: decided — we bill quarterly, invoices in UTC as immutable snapshots.",
+  },
+  {
+    id: "db-postgres",
+    label: "decision",
+    text: "@e: mongo or postgres for the new service?\n@f: postgres, we need transactions.\n@e: 👍 final call: Postgres for all new services.",
+  },
+  {
+    id: "retry-idempotency",
+    label: "decision",
+    text: "@g: orders keep double-charging on retries.\n@h: going forward every order write MUST carry an idempotency key. that's the rule.",
+  },
+  {
+    id: "lunch",
+    label: "not",
+    text: "@carol: anyone want lunch? cafeteria line is huge today lol",
+  },
+  {
+    id: "status-update",
+    label: "not",
+    text: "@i: deployed the hotfix to staging, watching metrics. will update in an hour.",
+  },
+  {
+    id: "still-debating",
+    label: "not",
+    text: "@j: should we use gRPC or REST between services?\n@k: gRPC is faster but REST is simpler.\n@j: hmm, let's think about it more and revisit next week.",
+  },
+  {
+    id: "question-open",
+    label: "not",
+    text: "@l: does anyone know if the payments API supports partial refunds? need it for a customer.",
+  },
+  {
+    id: "praise",
+    label: "not",
+    text: "@m: great work on the launch everyone 🎉 the dashboard looks amazing.",
+  },
+  {
+    id: "naming-convention",
+    label: "decision",
+    text: "@n: our event names are all over the place.\n@o: let's standardize: all analytics events use snake_case, past tense (e.g. order_created). from now on.",
+  },
+];

--- a/packages/ingest/src/eval/run.ts
+++ b/packages/ingest/src/eval/run.ts
@@ -1,0 +1,42 @@
+import { GOLDEN } from "./golden.js";
+import { recall } from "../distill/recall.js";
+import { extract } from "../distill/extract.js";
+import { gate } from "../distill/gate.js";
+
+/**
+ * Extraction eval (A.7): run the funnel's decision-detection stages over the golden set and report
+ * precision / recall / F1. A prediction is "decision" iff it survives recall AND gate() says propose.
+ * Run before/after prompt changes to catch regressions. Needs ANTHROPIC_API_KEY.
+ */
+export async function runEval(): Promise<void> {
+  let tp = 0;
+  let fp = 0;
+  let fn = 0;
+  let tn = 0;
+  for (const ex of GOLDEN) {
+    const recalled = await recall(ex.text, true);
+    let predicted: "decision" | "not" = "not";
+    if (recalled) {
+      const x = await extract(ex.id, ex.text);
+      predicted = gate(x) === "propose" ? "decision" : "not";
+    }
+    const ok = predicted === ex.label;
+    if (ex.label === "decision" && predicted === "decision") tp++;
+    else if (ex.label === "not" && predicted === "decision") fp++;
+    else if (ex.label === "decision" && predicted === "not") fn++;
+    else tn++;
+    console.log(`${ok ? "✓" : "✗"} ${ex.id.padEnd(20)} expected=${ex.label} predicted=${predicted}`);
+  }
+  const precision = tp + fp === 0 ? 1 : tp / (tp + fp);
+  const rec = tp + fn === 0 ? 1 : tp / (tp + fn);
+  const f1 = precision + rec === 0 ? 0 : (2 * precision * rec) / (precision + rec);
+  console.log(
+    `\nprecision=${precision.toFixed(2)} recall=${rec.toFixed(2)} f1=${f1.toFixed(2)} ` +
+      `(tp=${tp} fp=${fp} fn=${fn} tn=${tn}, n=${GOLDEN.length})`,
+  );
+  // Non-zero exit if recall drops below the gate (CI signal).
+  if (rec < 0.8) {
+    console.error("recall below 0.8 threshold");
+    process.exitCode = 1;
+  }
+}

--- a/packages/ingest/src/funnel.test.ts
+++ b/packages/ingest/src/funnel.test.ts
@@ -1,0 +1,120 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runFunnel, redactSecrets } from "./funnel.js";
+import type { SourceConnector, Unit, Channel } from "./connectors/SourceConnector.js";
+import type { Extraction } from "./distill/rubric.js";
+
+function extraction(over: Partial<Extraction>): Extraction {
+  return {
+    is_decision: true,
+    decision_type: "rule",
+    finality: "agreed",
+    rule_text: "Auth tokens are JWT with 15-minute expiry.",
+    rationale: "stateless",
+    alternatives_considered: [],
+    decided_by: ["@alice"],
+    scope_hint: "authentication",
+    surface_candidates: [],
+    confidence: 0.9,
+    evidence: [{ externalId: "e", quote: "lock it: JWT" }],
+    ...over,
+  };
+}
+
+class FakeConnector implements SourceConnector {
+  constructor(private readonly units: Unit[]) {}
+  async listChannels(): Promise<Channel[]> {
+    return [{ id: "C1", name: "eng" }];
+  }
+  async listUnitsSince(sourceRef: string): Promise<Unit[]> {
+    return this.units.filter((u) => u.sourceRef === sourceRef);
+  }
+}
+
+const unit = (id: string, ts: string, text: string): Unit => ({
+  externalId: id,
+  sourceRef: "C1",
+  ts,
+  text,
+  authors: ["@alice"],
+  permalink: "https://slack/x",
+});
+
+test("redactSecrets strips emails, tokens, and long hashes", () => {
+  const out = redactSecrets("mail me at a@b.com token xoxb-123456789012 hash deadbeefdeadbeefdeadbeefdeadbeef");
+  assert.match(out, /\[email\]/);
+  assert.match(out, /\[token\]/);
+  assert.match(out, /\[hash\]/);
+  assert.doesNotMatch(out, /a@b\.com/);
+});
+
+test("runFunnel: propose path builds an item, advances the cursor, records stats", async () => {
+  const connector = new FakeConnector([unit("C1/2", "2.0", "we decided: JWT"), unit("C1/1", "1.0", "chatter")]);
+  const res = await runFunnel({
+    connector,
+    orgId: "o",
+    projectId: "p",
+    connectionId: "conn",
+    sources: [{ sourceRef: "C1", cursor: null }],
+    tool: "slack",
+    recallFn: async (t) => t.includes("decided"),
+    extractFn: async () => extraction({}),
+  });
+  assert.equal(res.items.length, 1);
+  assert.equal(res.stats.seen, 2);
+  assert.equal(res.stats.recalled, 1);
+  assert.equal(res.stats.proposed, 1);
+  assert.equal(res.cursors.C1, "2.0", "cursor advanced to max ts seen (even across discarded units)");
+  const item = res.items[0]!;
+  assert.equal(item.scopeRef, "topic:authentication");
+  assert.equal(item.provenance && (item.provenance as { source: string }).source, "slack");
+  assert.equal(item.confidence, 90);
+});
+
+test("runFunnel: question and discard outcomes are counted, not filed", async () => {
+  const connector = new FakeConnector([
+    unit("C1/1", "1.0", "decided a"),
+    unit("C1/2", "2.0", "decided b"),
+    unit("C1/3", "3.0", "decided c"),
+  ]);
+  const map: Record<string, Extraction> = {
+    "C1/1": extraction({ finality: "proposed" }), // → question
+    "C1/2": extraction({ is_decision: false, confidence: 0.1 }), // → discard
+    "C1/3": extraction({}), // → propose
+  };
+  const res = await runFunnel({
+    connector,
+    orgId: "o",
+    projectId: "p",
+    connectionId: "conn",
+    sources: [{ sourceRef: "C1", cursor: null }],
+    recallFn: async () => true,
+    extractFn: async (id) => map[id]!,
+  });
+  assert.equal(res.stats.questions, 1);
+  assert.equal(res.stats.proposed, 1);
+  assert.ok(res.stats.discarded >= 1);
+  assert.equal(res.items.length, 1);
+});
+
+test("runFunnel: batch mode uses the injected batch extractor", async () => {
+  const connector = new FakeConnector([unit("C1/9", "9.0", "we decided: ship it")]);
+  let batched = false;
+  const res = await runFunnel({
+    connector,
+    orgId: "o",
+    projectId: "p",
+    connectionId: "conn",
+    sources: [{ sourceRef: "C1", cursor: null }],
+    batch: true,
+    recallFn: async () => true,
+    batchExtractFn: async (items) => {
+      batched = true;
+      return new Map(items.map((i) => [i.externalId, extraction({ surface_candidates: ["POST /ship"] })]));
+    },
+  });
+  assert.equal(batched, true);
+  assert.equal(res.items.length, 1);
+  assert.equal(res.items[0]!.scopeKind, "surface");
+  assert.equal(res.items[0]!.scopeRef, "http:POST /ship");
+});

--- a/packages/ingest/src/funnel.ts
+++ b/packages/ingest/src/funnel.ts
@@ -1,0 +1,150 @@
+import { createHash } from "node:crypto";
+import type { SourceConnector, Unit } from "./connectors/SourceConnector.js";
+import type { ProposedItem } from "./client.js";
+import { recall as defaultRecall } from "./distill/recall.js";
+import { extract as defaultExtract, extractBatch } from "./distill/extract.js";
+import { gate } from "./distill/gate.js";
+import { resolveScope } from "./distill/scope.js";
+import { MODELS } from "./distill/llm.js";
+import type { Extraction } from "./distill/rubric.js";
+
+export interface FunnelStats {
+  seen: number;
+  recalled: number;
+  proposed: number;
+  questions: number;
+  discarded: number;
+}
+export interface FunnelResult {
+  items: ProposedItem[];
+  cursors: Record<string, string>;
+  stats: FunnelStats;
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+/**
+ * Retention/redaction: strip obvious secrets/PII before any text leaves for the LLM or is stored as
+ * evidence. Conservative — emails, bearer tokens, and long key-like strings. (Phase 4 hardening.)
+ */
+export function redactSecrets(text: string): string {
+  return text
+    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "[email]")
+    .replace(/\b(?:sk|xox[baprs]|ghp|gho|glpat|AKIA)[-_A-Za-z0-9]{8,}\b/g, "[token]")
+    .replace(/\bBearer\s+[A-Za-z0-9._-]{12,}\b/gi, "Bearer [token]")
+    .replace(/\b[A-Fa-f0-9]{32,}\b/g, "[hash]");
+}
+
+/**
+ * The Part-A funnel (stages 0–6) over every allowlisted source of one connection. Two-phase so the
+ * expensive extraction can run inline (fast, interactive) or via the Anthropic Batch API (--batch,
+ * 50% cost, for scheduled sweeps). Idempotency is enforced server-side on (connectionId, externalId,
+ * contentHash) by fileProposedDecision.
+ */
+export async function runFunnel(opts: {
+  connector: SourceConnector;
+  orgId: string;
+  projectId: string;
+  connectionId: string;
+  sources: Array<{ sourceRef: string; cursor: string | null }>;
+  tool?: string;
+  useHaiku?: boolean;
+  batch?: boolean;
+  log?: (msg: string) => void;
+  // Injectable for tests — default to the real Haiku/Sonnet stages.
+  recallFn?: (text: string, useHaiku: boolean) => Promise<boolean>;
+  extractFn?: (externalId: string, text: string) => Promise<Extraction>;
+  batchExtractFn?: (items: Array<{ externalId: string; text: string }>) => Promise<Map<string, Extraction>>;
+}): Promise<FunnelResult> {
+  const log = opts.log ?? (() => {});
+  const source = opts.tool ?? "slack";
+  const recall = opts.recallFn ?? defaultRecall;
+  const extract = opts.extractFn ?? defaultExtract;
+  const batchExtract = opts.batchExtractFn ?? extractBatch;
+  const stats: FunnelStats = { seen: 0, recalled: 0, proposed: 0, questions: 0, discarded: 0 };
+  const cursors: Record<string, string> = {};
+
+  // Phase 1 — collect units + advance cursors + cheap recall filter.
+  type Survivor = { unit: Unit; text: string };
+  const survivors: Survivor[] = [];
+  for (const src of opts.sources) {
+    const units = await opts.connector.listUnitsSince(src.sourceRef, src.cursor);
+    log(`  ${src.sourceRef}: ${units.length} unit(s) since cursor`);
+    let maxTs = src.cursor ?? "0";
+    for (const u of units) {
+      stats.seen++;
+      if (u.ts > maxTs) maxTs = u.ts;
+      const text = redactSecrets(u.text);
+      if (!(await recall(text, opts.useHaiku ?? true))) {
+        stats.discarded++;
+        continue;
+      }
+      stats.recalled++;
+      survivors.push({ unit: u, text });
+    }
+    cursors[src.sourceRef] = maxTs;
+  }
+
+  // Phase 2 — extraction (batch or inline).
+  const extractions = new Map<string, Awaited<ReturnType<typeof extract>>>();
+  if (opts.batch) {
+    log(`  batch-extracting ${survivors.length} survivor(s)…`);
+    const res = await batchExtract(survivors.map((s) => ({ externalId: s.unit.externalId, text: s.text })));
+    for (const [k, v] of res) extractions.set(k, v);
+  } else {
+    for (const s of survivors) extractions.set(s.unit.externalId, await extract(s.unit.externalId, s.text));
+  }
+
+  // Phase 3 — gate → scope → build proposed items.
+  const items: ProposedItem[] = [];
+  for (const s of survivors) {
+    const u = s.unit;
+    const x = extractions.get(u.externalId);
+    if (!x) {
+      stats.discarded++;
+      continue;
+    }
+    const action = gate(x);
+    if (action === "discard") {
+      stats.discarded++;
+      continue;
+    }
+    if (action === "question") {
+      stats.questions++;
+      log(`    ~ question (not agreed): ${x.rule_text.slice(0, 80)}`);
+      continue;
+    }
+    const scope = resolveScope(x.surface_candidates, x.scope_hint);
+    items.push({
+      orgId: opts.orgId,
+      projectId: opts.projectId,
+      scopeKind: scope.scopeKind,
+      scopeRef: scope.scopeRef,
+      ruleText: x.rule_text,
+      decisionType: x.decision_type === "architecture" ? "architecture" : "rule",
+      provenance: {
+        source,
+        connectionId: opts.connectionId,
+        externalId: u.externalId,
+        url: u.permalink ?? null,
+        evidence: x.evidence,
+        extractorModel: MODELS.extract,
+        confidence: x.confidence,
+        decidedBy: x.decided_by,
+        decidedAt: u.ts,
+        scopeHint: x.scope_hint,
+        rationale: x.rationale,
+        alternatives: x.alternatives_considered,
+      },
+      connectionId: opts.connectionId,
+      externalId: u.externalId,
+      contentHash: sha256(u.text),
+      confidence: Math.round(x.confidence * 100),
+    });
+    stats.proposed++;
+    log(`    ✓ proposed [${scope.scopeRef}] ${x.rule_text.slice(0, 80)}`);
+  }
+  return { items, cursors, stats };
+}

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+import { LockstepClient } from "./client.js";
+import { StubConnector } from "./connectors/StubConnector.js";
+import { ComposioConnector, type Tool } from "./connectors/ComposioConnector.js";
+import { NangoConnector } from "./connectors/NangoConnector.js";
+import type { SourceConnector } from "./connectors/SourceConnector.js";
+import { runFunnel } from "./funnel.js";
+import { runEval } from "./eval/run.js";
+
+/**
+ * lockstep-ingest — the v2 sweep worker CLI.
+ *
+ *   lockstep-ingest channels --entity <projectId>        list Slack channels (to find allowlist ids)
+ *   lockstep-ingest connect  --connection <id> --entity <projectId>   run Composio OAuth, finalize
+ *   lockstep-ingest sweep    [--stub] [--no-haiku]        one-shot: fetch → distill → propose
+ *   lockstep-ingest serve    [--interval <sec>]           loop sweep on an interval (default 900s)
+ *
+ * Env: LOCKSTEP_API_URL, LOCKSTEP_INGEST_TOKEN, COMPOSIO_API_KEY, ANTHROPIC_API_KEY.
+ */
+
+function flag(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+function has(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+function env(name: string, required = false): string {
+  const v = process.env[name];
+  if (!v && required) throw new Error(`${name} is required`);
+  return v ?? "";
+}
+function client(): LockstepClient {
+  return new LockstepClient(env("LOCKSTEP_API_URL") || "http://localhost:8080", env("LOCKSTEP_INGEST_TOKEN", true));
+}
+function composio(entity: string, tool: Tool = "slack"): ComposioConnector {
+  return new ComposioConnector(env("COMPOSIO_API_KEY", true), entity, tool);
+}
+function toolFlag(): Tool {
+  return (flag("tool") as Tool) ?? "slack";
+}
+
+async function cmdChannels(): Promise<void> {
+  const entity = flag("entity");
+  if (!entity) throw new Error("--entity <projectId> required");
+  const chans = await composio(entity, toolFlag()).listChannels();
+  for (const c of chans) console.log(`${c.id}\t${c.name}`);
+  console.log(`\n${chans.length} source(s). Add the ones you want swept in the dashboard Connections page.`);
+}
+
+async function cmdConnect(): Promise<void> {
+  const connectionId = flag("connection");
+  const entity = flag("entity");
+  if (!connectionId || !entity) throw new Error("--connection <id> --entity <projectId> required");
+  const conn = composio(entity, toolFlag());
+  const { redirectUrl, connectedAccountId } = await conn.initiate();
+  console.log(`\nAuthorize Slack here, then return:\n\n  ${redirectUrl}\n`);
+  process.stdout.write("Waiting for authorization");
+  for (let i = 0; i < 60; i++) {
+    await new Promise((r) => setTimeout(r, 3000));
+    process.stdout.write(".");
+    if (await conn.isActive(connectedAccountId)) {
+      await client().finalizeConnection(connectionId, connectedAccountId);
+      console.log(`\n✓ Connected. Connection ${connectionId} is now active.`);
+      return;
+    }
+  }
+  console.log(`\nTimed out. Once authorized, finalize manually via the worker endpoint with account ${connectedAccountId}.`);
+}
+
+async function sweepOnce(): Promise<void> {
+  const ls = client();
+  const useStub = has("stub");
+  const useNango = has("nango");
+  const batch = has("batch");
+  const useHaiku = !has("no-haiku");
+  const work = await ls.getWork();
+  console.log(`[sweep] ${work.length} connection(s) with allowlisted sources${batch ? " (batch mode)" : ""}`);
+  for (const w of work) {
+    if (!useStub && !w.connectedAccountId) {
+      console.log(`[sweep] skip ${w.connectionId} (not connected)`);
+      continue;
+    }
+    const connector: SourceConnector = useStub
+      ? new StubConnector()
+      : useNango
+        ? new NangoConnector(env("NANGO_SECRET_KEY", true), w.connectedAccountId ?? w.entity, w.tool)
+        : composio(w.entity, w.tool as Tool);
+    console.log(`[sweep] connection ${w.connectionId} (${w.tool}) — ${w.sources.length} source(s)`);
+    const { items, cursors, stats } = await runFunnel({
+      connector,
+      orgId: w.orgId,
+      projectId: w.projectId,
+      connectionId: w.connectionId,
+      sources: w.sources.map((s) => ({ sourceRef: s.sourceRef, cursor: s.cursor })),
+      tool: w.tool,
+      useHaiku,
+      batch,
+      log: (m) => console.log(m),
+    });
+    const res = await ls.postProposed(items);
+    for (const [sourceRef, cursor] of Object.entries(cursors)) {
+      await ls.setWatermark(w.orgId, w.connectionId, sourceRef, cursor);
+    }
+    console.log(
+      `[sweep] seen=${stats.seen} recalled=${stats.recalled} proposed=${stats.proposed} ` +
+        `questions=${stats.questions} discarded=${stats.discarded} → filed=${res.filed} deduped=${res.deduped}`,
+    );
+  }
+  console.log("[sweep] done");
+}
+
+async function cmdServe(): Promise<void> {
+  const interval = Number(flag("interval") ?? 900) * 1000;
+  console.log(`[serve] sweeping every ${interval / 1000}s`);
+  for (;;) {
+    try {
+      await sweepOnce();
+    } catch (e) {
+      console.error("[serve] sweep error:", e);
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+}
+
+async function main(): Promise<void> {
+  const cmd = process.argv[2];
+  switch (cmd) {
+    case "channels":
+      return cmdChannels();
+    case "connect":
+      return cmdConnect();
+    case "sweep":
+      return sweepOnce();
+    case "serve":
+      return cmdServe();
+    case "eval":
+      return runEval();
+    default:
+      console.log("usage: lockstep-ingest <channels|connect|sweep|serve|eval> [flags]");
+      process.exit(cmd ? 1 : 0);
+  }
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/packages/ingest/tsconfig.json
+++ b/packages/ingest/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/web/app/actions.ts
+++ b/packages/web/app/actions.ts
@@ -41,3 +41,60 @@ export async function inviteAction(formData: FormData): Promise<void> {
   });
   revalidatePath(`/project/${orgId}/${projectId}`);
 }
+
+/* ── v2 ingestion: review queue + connections ── */
+
+export async function confirmDecisionAction(formData: FormData): Promise<void> {
+  const orgId = String(formData.get("orgId") ?? "");
+  const projectId = String(formData.get("projectId") ?? "");
+  const id = String(formData.get("id") ?? "");
+  await apiPost(`/orgs/${orgId}/decisions/${id}/confirm`, {});
+  revalidatePath(`/project/${orgId}/${projectId}/review-queue`);
+}
+
+export async function rejectDecisionAction(formData: FormData): Promise<void> {
+  const orgId = String(formData.get("orgId") ?? "");
+  const projectId = String(formData.get("projectId") ?? "");
+  const id = String(formData.get("id") ?? "");
+  await apiPost(`/orgs/${orgId}/decisions/${id}/reject`, {});
+  revalidatePath(`/project/${orgId}/${projectId}/review-queue`);
+}
+
+export async function createConnectionAction(formData: FormData): Promise<void> {
+  const orgId = String(formData.get("orgId") ?? "");
+  const projectId = String(formData.get("projectId") ?? "");
+  await apiPost(`/orgs/${orgId}/projects/${projectId}/connections`, {
+    tool: String(formData.get("tool") ?? "slack"),
+  });
+  revalidatePath(`/project/${orgId}/${projectId}/connections`);
+}
+
+export async function addAllowlistAction(formData: FormData): Promise<void> {
+  const orgId = String(formData.get("orgId") ?? "");
+  const projectId = String(formData.get("projectId") ?? "");
+  await apiPost(`/orgs/${orgId}/projects/${projectId}/allowlist`, {
+    connectionId: String(formData.get("connectionId") ?? ""),
+    sourceKind: String(formData.get("sourceKind") ?? "channel"),
+    sourceRef: String(formData.get("sourceRef") ?? ""),
+    sourceName: String(formData.get("sourceName") ?? ""),
+  });
+  revalidatePath(`/project/${orgId}/${projectId}/connections`);
+}
+
+export async function deriveGraphAction(formData: FormData): Promise<void> {
+  const orgId = String(formData.get("orgId") ?? "");
+  const projectId = String(formData.get("projectId") ?? "");
+  await apiPost(`/orgs/${orgId}/projects/${projectId}/graph/derive`, {});
+  revalidatePath(`/project/${orgId}/${projectId}/graph`);
+}
+
+export async function addGraphEdgeAction(formData: FormData): Promise<void> {
+  const orgId = String(formData.get("orgId") ?? "");
+  const projectId = String(formData.get("projectId") ?? "");
+  await apiPost(`/orgs/${orgId}/projects/${projectId}/graph/edges`, {
+    fromId: String(formData.get("fromId") ?? ""),
+    toId: String(formData.get("toId") ?? ""),
+    kind: String(formData.get("kind") ?? "relates"),
+  });
+  revalidatePath(`/project/${orgId}/${projectId}/graph`);
+}

--- a/packages/web/app/components/Nav.tsx
+++ b/packages/web/app/components/Nav.tsx
@@ -18,17 +18,23 @@ export interface NavCounts {
   tasks?: number;
   contracts?: number;
   dependencies?: number;
+  review?: number;
 }
 
 export function Nav({ base, counts }: { base: string; counts: NavCounts }) {
   const pathname = usePathname();
   const items = [
     { href: "", label: "Overview", Icon: IconOverview, badge: undefined as number | undefined },
+    { href: "/review-queue", label: "Review", Icon: IconQuestions, badge: counts.review },
     { href: "/decisions", label: "Decisions", Icon: IconDecisions, badge: counts.decisions },
+    { href: "/search", label: "Search", Icon: IconOverview, badge: undefined },
     { href: "/questions", label: "Questions", Icon: IconQuestions, badge: counts.questions },
     { href: "/tasks", label: "Tasks", Icon: IconTasks, badge: counts.tasks },
     { href: "/contracts", label: "Contracts", Icon: IconContracts, badge: counts.contracts },
     { href: "/dependencies", label: "Dependencies", Icon: IconDependencies, badge: counts.dependencies },
+    { href: "/graph", label: "Org graph", Icon: IconDependencies, badge: undefined },
+    { href: "/connections", label: "Connections", Icon: IconMembers, badge: undefined },
+    { href: "/notifications", label: "Notifications", Icon: IconActivity, badge: undefined },
     { href: "/activity", label: "Activity", Icon: IconActivity, badge: undefined },
     { href: "/members", label: "Members & Repos", Icon: IconMembers, badge: undefined },
   ];

--- a/packages/web/app/lib/data.ts
+++ b/packages/web/app/lib/data.ts
@@ -4,6 +4,85 @@ import type { ProjectOverview } from "./types";
 export const getOverview = (orgId: string, projectId: string) =>
   apiGet<ProjectOverview>(`/orgs/${orgId}/projects/${projectId}/overview`);
 
+/* ── v2 ingestion: review queue + connections ── */
+
+export interface ProvenanceEvidence {
+  externalId: string;
+  quote: string;
+}
+export interface Provenance {
+  source?: string;
+  url?: string | null;
+  evidence?: ProvenanceEvidence[];
+  confidence?: number;
+  decidedBy?: string[];
+  scopeHint?: string;
+  rationale?: string;
+  supersedes?: string;
+}
+export interface ProvenanceRow {
+  source: string;
+  externalId: string | null;
+  url: string | null;
+  evidence: ProvenanceEvidence[] | null;
+  confidence: number | null;
+}
+export interface ProposedDecision {
+  id: string;
+  scopeKind: string;
+  scopeRef: string;
+  status: string;
+  origin: string;
+  ruleText: string;
+  decisionType: string;
+  impact: number;
+  provenance: Provenance | null;
+  provenances?: ProvenanceRow[];
+  createdAt: string;
+}
+export interface SourceConnection {
+  id: string;
+  tool: string;
+  entity: string;
+  status: string;
+  connectedAccountId: string | null;
+}
+export interface AllowlistEntry {
+  id: string;
+  connectionId: string;
+  sourceKind: string;
+  sourceRef: string;
+  sourceName: string | null;
+  enabled: boolean;
+}
+
+export const getProposed = (orgId: string, projectId: string) =>
+  apiGet<{ decisions: ProposedDecision[] }>(`/orgs/${orgId}/projects/${projectId}/proposed`);
+
+export const getConnections = (orgId: string, projectId: string) =>
+  apiGet<{ connections: SourceConnection[] }>(`/orgs/${orgId}/projects/${projectId}/connections`);
+
+export const getAllowlist = (orgId: string, projectId: string) =>
+  apiGet<{ allowlist: AllowlistEntry[] }>(`/orgs/${orgId}/projects/${projectId}/allowlist`);
+
+export const searchDecisions = (orgId: string, projectId: string, qs: string) =>
+  apiGet<{ decisions: ProposedDecision[] }>(`/orgs/${orgId}/projects/${projectId}/decisions/search${qs}`);
+
+export interface GraphNode {
+  id: string;
+  kind: string;
+  ref: string;
+  label: string | null;
+  source: string;
+}
+export interface GraphEdge {
+  fromId: string;
+  toId: string;
+  kind: string;
+}
+export const getGraph = (orgId: string, projectId: string) =>
+  apiGet<{ nodes: GraphNode[]; edges: GraphEdge[] }>(`/orgs/${orgId}/projects/${projectId}/graph`);
+
 export function timeAgo(iso: string): string {
   const d = new Date(iso).getTime();
   if (Number.isNaN(d)) return "";

--- a/packages/web/app/project/[orgId]/[projectId]/connections/page.tsx
+++ b/packages/web/app/project/[orgId]/[projectId]/connections/page.tsx
@@ -1,0 +1,109 @@
+import { getConnections, getAllowlist } from "@/lib/data";
+import { PageHead, EmptyState, StatusPill } from "@/components/ui";
+import { IconMembers } from "@/components/icons";
+import { createConnectionAction, addAllowlistAction } from "@/actions";
+
+export const dynamic = "force-dynamic";
+
+const TOOLS = ["slack", "jira", "notion", "confluence"] as const;
+const SOURCE_KIND: Record<string, string> = { slack: "channel", jira: "project", notion: "database", confluence: "space" };
+const SOURCE_HINT: Record<string, string> = {
+  slack: "channel id e.g. C0123456789",
+  jira: "project key e.g. PLATFORM",
+  notion: "database id or search term",
+  confluence: "space key e.g. ENG",
+};
+
+export default async function Page({ params }: { params: { orgId: string; projectId: string } }) {
+  const { orgId, projectId } = params;
+  const [conns, allow] = await Promise.all([getConnections(orgId, projectId), getAllowlist(orgId, projectId)]);
+  const connections = conns?.connections ?? [];
+  const allowlist = allow?.allowlist ?? [];
+  const connectedTools = new Set(connections.map((c) => c.tool));
+
+  return (
+    <>
+      <PageHead
+        title="Connections"
+        subtitle="Connect a tool via Composio, then allowlist the exact sources to sweep. Only allowlisted sources are read."
+      />
+
+      <form action={createConnectionAction} className="card animate-in" style={{ padding: 16, marginBottom: 16 }}>
+        <input type="hidden" name="orgId" value={orgId} />
+        <input type="hidden" name="projectId" value={projectId} />
+        <div className="title" style={{ marginBottom: 8 }}>Connect a tool</div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <select name="tool" className="input" defaultValue="slack">
+            {TOOLS.filter((t) => !connectedTools.has(t)).map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+          <button className="btn primary">Create connection</button>
+        </div>
+      </form>
+
+      {connections.length === 0 ? (
+        <EmptyState icon={<IconMembers />} title="No connections yet">
+          Connect Slack, Jira, Notion, or Confluence to start distilling decisions from your team&apos;s work.
+        </EmptyState>
+      ) : (
+        connections.map((c) => {
+          const entries = allowlist.filter((a) => a.connectionId === c.id);
+          const kind = SOURCE_KIND[c.tool] ?? "channel";
+          return (
+            <div className="card animate-in" key={c.id} style={{ marginBottom: 16, padding: 16 }}>
+              <div className="row" style={{ marginBottom: 8 }}>
+                <div className="body">
+                  <div className="title" style={{ textTransform: "capitalize" }}>{c.tool}</div>
+                  <div className="meta">
+                    <span className="code-ref">{c.id}</span>
+                    {c.connectedAccountId && <span>account {c.connectedAccountId.slice(0, 12)}…</span>}
+                  </div>
+                </div>
+                <StatusPill status={c.status} />
+              </div>
+
+              {c.status !== "active" && (
+                <pre className="code-ref" style={{ padding: 10, overflowX: "auto", margin: "6px 0" }}>
+                  {`lockstep-ingest connect --connection ${c.id} --entity ${c.entity} --tool ${c.tool}`}
+                </pre>
+              )}
+
+              {entries.length > 0 && (
+                <div className="rows" style={{ margin: "8px 0" }}>
+                  {entries.map((a) => (
+                    <div className="row" key={a.id}>
+                      <div className="body">
+                        <div className="title">{a.sourceName ?? a.sourceRef}</div>
+                        <div className="meta">
+                          <span className="code-ref">{a.sourceRef}</span>
+                          <span className="pill plain">{a.sourceKind}</span>
+                        </div>
+                      </div>
+                      <StatusPill status={a.enabled ? "enabled" : "disabled"} />
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <form action={addAllowlistAction} style={{ marginTop: 8 }}>
+                <input type="hidden" name="orgId" value={orgId} />
+                <input type="hidden" name="projectId" value={projectId} />
+                <input type="hidden" name="connectionId" value={c.id} />
+                <input type="hidden" name="sourceKind" value={kind} />
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  <input name="sourceRef" placeholder={SOURCE_HINT[c.tool]} className="input" required />
+                  <input name="sourceName" placeholder="label (optional)" className="input" />
+                  <button className="btn primary">Add {kind}</button>
+                </div>
+                <p style={{ color: "var(--muted)", marginTop: 6, marginBottom: 0 }}>
+                  Find ids with <span className="code-ref">lockstep-ingest channels --entity {c.entity} --tool {c.tool}</span>.
+                </p>
+              </form>
+            </div>
+          );
+        })
+      )}
+    </>
+  );
+}

--- a/packages/web/app/project/[orgId]/[projectId]/graph/page.tsx
+++ b/packages/web/app/project/[orgId]/[projectId]/graph/page.tsx
@@ -1,0 +1,98 @@
+import { getGraph } from "@/lib/data";
+import { PageHead, EmptyState } from "@/components/ui";
+import { IconDependencies } from "@/components/icons";
+import { deriveGraphAction, addGraphEdgeAction } from "@/actions";
+
+export const dynamic = "force-dynamic";
+
+const KIND_ORDER = ["project", "team", "topic", "surface", "doc", "person"];
+
+export default async function Page({ params }: { params: { orgId: string; projectId: string } }) {
+  const { orgId, projectId } = params;
+  const g = await getGraph(orgId, projectId);
+  const nodes = g?.nodes ?? [];
+  const edges = g?.edges ?? [];
+  const label = (id: string) => {
+    const n = nodes.find((x) => x.id === id);
+    return n ? `${n.kind}:${n.label ?? n.ref}` : id.slice(0, 8);
+  };
+  const byKind = KIND_ORDER.map((k) => ({ kind: k, items: nodes.filter((n) => n.kind === k) })).filter((x) => x.items.length);
+
+  return (
+    <>
+      <PageHead
+        title="Org graph"
+        subtitle="Teams, topics, surfaces and people — this is what gives non-code decisions a blast radius."
+      />
+
+      <form action={deriveGraphAction} style={{ marginBottom: 16 }}>
+        <input type="hidden" name="orgId" value={orgId} />
+        <input type="hidden" name="projectId" value={projectId} />
+        <button className="btn primary">Derive from members &amp; decisions</button>
+      </form>
+
+      {nodes.length === 0 ? (
+        <EmptyState icon={<IconDependencies />} title="Graph is empty">
+          Click “Derive” to auto-build nodes from your team and the decisions distilled so far.
+        </EmptyState>
+      ) : (
+        <>
+          <div className="card animate-in" style={{ marginBottom: 16 }}>
+            <div className="rows">
+              {byKind.map((grp) => (
+                <div className="row" key={grp.kind}>
+                  <div className="body">
+                    <div className="title" style={{ textTransform: "capitalize" }}>{grp.kind}</div>
+                    <div className="meta" style={{ flexWrap: "wrap", gap: 6 }}>
+                      {grp.items.map((n) => (
+                        <span key={n.id} className="pill plain">{n.label ?? n.ref}</span>
+                      ))}
+                    </div>
+                  </div>
+                  <span className="pill plain">{grp.items.length}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <PageHead title="Edges" subtitle={`${edges.length} connection(s)`} />
+          <div className="card animate-in" style={{ marginBottom: 16 }}>
+            <div className="rows stagger">
+              {edges.slice(0, 100).map((e, i) => (
+                <div className="row" key={i}>
+                  <div className="body">
+                    <div className="meta">
+                      <span className="code-ref">{label(e.fromId)}</span>
+                      <span>—{e.kind}→</span>
+                      <span className="code-ref">{label(e.toId)}</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <form action={addGraphEdgeAction} className="card animate-in" style={{ padding: 16 }}>
+            <input type="hidden" name="orgId" value={orgId} />
+            <input type="hidden" name="projectId" value={projectId} />
+            <div className="title" style={{ marginBottom: 8 }}>Add / correct an edge</div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              <select name="fromId" className="input" required>
+                {nodes.map((n) => (
+                  <option key={n.id} value={n.id}>{n.kind}: {n.label ?? n.ref}</option>
+                ))}
+              </select>
+              <select name="toId" className="input" required>
+                {nodes.map((n) => (
+                  <option key={n.id} value={n.id}>{n.kind}: {n.label ?? n.ref}</option>
+                ))}
+              </select>
+              <input name="kind" placeholder="relates" className="input" />
+              <button className="btn primary">Add edge</button>
+            </div>
+          </form>
+        </>
+      )}
+    </>
+  );
+}

--- a/packages/web/app/project/[orgId]/[projectId]/layout.tsx
+++ b/packages/web/app/project/[orgId]/[projectId]/layout.tsx
@@ -5,6 +5,7 @@ import { Nav } from "@/components/Nav";
 import { ProjectSwitcher } from "@/components/ProjectSwitcher";
 import { IconLogout } from "@/components/icons";
 import { logoutAction } from "@/actions";
+import { getProposed } from "@/lib/data";
 import type { Me, OrgOverview, ProjectOverview } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
@@ -22,6 +23,7 @@ export default async function ProjectLayout({
 
   const org = await apiGet<OrgOverview>(`/orgs/${orgId}/overview`);
   const o = await apiGet<ProjectOverview>(`/orgs/${orgId}/projects/${projectId}/overview`);
+  const proposed = await getProposed(orgId, projectId);
   const projectName = org?.projects.find((p) => p.id === projectId)?.name ?? "project";
   const base = `/project/${orgId}/${projectId}`;
   const counts = {
@@ -30,6 +32,7 @@ export default async function ProjectLayout({
     tasks: o?.tasks.filter((t) => t.status !== "closed").length,
     contracts: o?.contracts.length,
     dependencies: o?.dependencies.length,
+    review: proposed?.decisions.length,
   };
   const initial = (me.principal.githubLogin[0] ?? "?").toUpperCase();
 

--- a/packages/web/app/project/[orgId]/[projectId]/notifications/page.tsx
+++ b/packages/web/app/project/[orgId]/[projectId]/notifications/page.tsx
@@ -1,0 +1,52 @@
+import { searchDecisions } from "@/lib/data";
+import { PageHead, EmptyState, StatusPill } from "@/components/ui";
+import { IconActivity } from "@/components/icons";
+import { timeAgo } from "@/lib/data";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Human blast-radius view: decisions with org-wide reach (impact > 0) — the ones a person on an
+ * affected team should know about. Cross-cutting decisions are also fanned out to agents' inboxes on
+ * confirm; this is the human-facing side of the same signal.
+ */
+export default async function Page({ params }: { params: { orgId: string; projectId: string } }) {
+  const { orgId, projectId } = params;
+  const data = await searchDecisions(orgId, projectId, "");
+  const items = (data?.decisions ?? [])
+    .filter((d) => d.impact > 0 && d.status !== "rejected" && d.status !== "proposed")
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+  return (
+    <>
+      <PageHead
+        title="Notifications"
+        subtitle="Decisions with a blast radius — cross-cutting rules that affect more than the area they came from."
+      />
+      {items.length === 0 ? (
+        <EmptyState icon={<IconActivity />} title="Nothing high-impact yet">
+          When a decision affects a surface others consume — or a topic several people work on — it shows up here.
+        </EmptyState>
+      ) : (
+        <div className="card animate-in">
+          <div className="rows stagger">
+            {items.map((d) => (
+              <div className="row" key={d.id}>
+                <div className="body">
+                  <div className="title">{d.ruleText || d.scopeRef}</div>
+                  <div className="meta">
+                    <span className="code-ref">{d.scopeRef}</span>
+                    <span className="pill plain">impact {d.impact}</span>
+                    {d.provenance?.source && <span>via {d.provenance.source}</span>}
+                    <span>{timeAgo(d.createdAt)}</span>
+                  </div>
+                </div>
+                <StatusPill status={d.status} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/web/app/project/[orgId]/[projectId]/review-queue/page.tsx
+++ b/packages/web/app/project/[orgId]/[projectId]/review-queue/page.tsx
@@ -1,0 +1,107 @@
+import { getProposed } from "@/lib/data";
+import { PageHead, EmptyState } from "@/components/ui";
+import { IconQuestions } from "@/components/icons";
+import { confirmDecisionAction, rejectDecisionAction } from "@/actions";
+
+export const dynamic = "force-dynamic";
+
+export default async function Page({ params }: { params: { orgId: string; projectId: string } }) {
+  const { orgId, projectId } = params;
+  const data = await getProposed(orgId, projectId);
+  const items = data?.decisions ?? [];
+
+  return (
+    <>
+      <PageHead
+        title="Review queue"
+        subtitle="Decisions distilled from your connected tools. Nothing binds until you confirm it here."
+      />
+      {items.length === 0 ? (
+        <EmptyState icon={<IconQuestions />} title="Nothing to review">
+          When a sweep distills a decision from an allowlisted Slack channel, it lands here as a draft with
+          the exact quote it came from.
+        </EmptyState>
+      ) : (
+        <div className="rows stagger">
+          {items.map((d) => {
+            const p = d.provenance ?? {};
+            const conf = typeof p.confidence === "number" ? Math.round(p.confidence * 100) : null;
+            // Prefer the fused provenance rows (one decision, many sources); fall back to the version's.
+            const rows =
+              d.provenances && d.provenances.length > 0
+                ? d.provenances
+                : [{ source: p.source ?? "source", externalId: null, url: p.url ?? null, evidence: p.evidence ?? [], confidence: null }];
+            return (
+              <div className="card animate-in" key={d.id} style={{ marginBottom: 14 }}>
+                <div className="body" style={{ padding: "4px 2px" }}>
+                  <div className="title" style={{ fontSize: 16 }}>{d.ruleText}</div>
+                  <div className="meta" style={{ marginTop: 6 }}>
+                    <span className="code-ref">{d.scopeRef}</span>
+                    <span className="pill plain">{d.scopeKind}</span>
+                    <span className="pill plain">{d.decisionType}</span>
+                    {conf !== null && <span>confidence {conf}%</span>}
+                    {rows.length > 1 && <span className="pill plain">{rows.length} sources</span>}
+                  </div>
+
+                  {p.supersedes && (
+                    <p style={{ margin: "8px 0 0", color: "var(--red, #e5484d)" }}>
+                      ⚠ May supersede an existing binding decision on <span className="code-ref">{d.scopeRef}</span> — review both.
+                    </p>
+                  )}
+
+                  {p.rationale && <p style={{ margin: "10px 0 0", color: "var(--muted)" }}>{p.rationale}</p>}
+
+                  {rows.map((row, ri) => (
+                    <div key={ri} style={{ marginTop: 10 }}>
+                      <div className="meta" style={{ marginBottom: 4 }}>
+                        <span>via {row.source}</span>
+                        {row.url && (
+                          <a href={row.url} target="_blank" rel="noreferrer" className="code-ref">open ↗</a>
+                        )}
+                      </div>
+                      {(row.evidence ?? []).map((e, i) => (
+                        <blockquote
+                          key={i}
+                          style={{
+                            margin: "6px 0 0",
+                            padding: "8px 12px",
+                            borderLeft: "3px solid var(--violet)",
+                            background: "var(--surface)",
+                            borderRadius: "var(--radius-sm)",
+                            color: "var(--text)",
+                            fontStyle: "italic",
+                          }}
+                        >
+                          “{e.quote}”
+                        </blockquote>
+                      ))}
+                    </div>
+                  ))}
+
+                  <div className="meta" style={{ marginTop: 10, gap: 12 }}>
+                    {p.decidedBy && p.decidedBy.length > 0 && <span>decided by {p.decidedBy.join(", ")}</span>}
+                  </div>
+
+                  <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
+                    <form action={confirmDecisionAction}>
+                      <input type="hidden" name="orgId" value={orgId} />
+                      <input type="hidden" name="projectId" value={projectId} />
+                      <input type="hidden" name="id" value={d.id} />
+                      <button className="btn primary">Confirm</button>
+                    </form>
+                    <form action={rejectDecisionAction}>
+                      <input type="hidden" name="orgId" value={orgId} />
+                      <input type="hidden" name="projectId" value={projectId} />
+                      <input type="hidden" name="id" value={d.id} />
+                      <button className="btn">Reject</button>
+                    </form>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/web/app/project/[orgId]/[projectId]/search/page.tsx
+++ b/packages/web/app/project/[orgId]/[projectId]/search/page.tsx
@@ -1,0 +1,81 @@
+import { searchDecisions } from "@/lib/data";
+import { PageHead, EmptyState, StatusPill } from "@/components/ui";
+import { IconDecisions } from "@/components/icons";
+
+export const dynamic = "force-dynamic";
+
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: { orgId: string; projectId: string };
+  searchParams: { q?: string; status?: string; origin?: string };
+}) {
+  const { orgId, projectId } = params;
+  const q = searchParams.q ?? "";
+  const status = searchParams.status ?? "";
+  const origin = searchParams.origin ?? "";
+  const qs =
+    "?" +
+    new URLSearchParams(
+      Object.entries({ q, status, origin }).filter(([, v]) => v) as [string, string][],
+    ).toString();
+  const data = await searchDecisions(orgId, projectId, qs === "?" ? "" : qs);
+  const items = data?.decisions ?? [];
+
+  return (
+    <>
+      <PageHead title="Search decisions" subtitle="Ask what the team decided — answered from the ledger, with provenance." />
+
+      <form method="get" className="card animate-in" style={{ padding: 16, marginBottom: 16 }}>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <input name="q" defaultValue={q} placeholder="what did we decide about…" className="input" style={{ flex: 1, minWidth: 220 }} />
+          <select name="status" defaultValue={status} className="input">
+            <option value="">any status</option>
+            <option value="binding">binding</option>
+            <option value="open">open</option>
+            <option value="proposed">proposed</option>
+            <option value="superseded">superseded</option>
+          </select>
+          <select name="origin" defaultValue={origin} className="input">
+            <option value="">any origin</option>
+            <option value="agent">agent</option>
+            <option value="ingested">ingested</option>
+          </select>
+          <button className="btn primary">Search</button>
+        </div>
+      </form>
+
+      {items.length === 0 ? (
+        <EmptyState icon={<IconDecisions />} title={q ? "No matches" : "Search the decision ledger"}>
+          Try a topic, a rule keyword, a surface, or a source quote.
+        </EmptyState>
+      ) : (
+        <div className="card animate-in">
+          <div className="rows stagger">
+            {items.map((d) => {
+              const url = d.provenance?.url;
+              return (
+                <div className="row" key={d.id}>
+                  <div className="body">
+                    <div className="title">{d.ruleText || d.scopeRef}</div>
+                    <div className="meta">
+                      <span className="code-ref">{d.scopeRef}</span>
+                      <span className="pill plain">{d.scopeKind}</span>
+                      <span className="pill plain">{d.origin}</span>
+                      {d.provenance?.source && <span>via {d.provenance.source}</span>}
+                      {url && (
+                        <a href={url} target="_blank" rel="noreferrer" className="code-ref">source ↗</a>
+                      )}
+                    </div>
+                  </div>
+                  <StatusPill status={d.status} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## What

Adds the v2 ingestion pipeline, the reach/dependency graph, and the dashboard UI that drives them.

### Ingest worker (`packages/ingest`)
- Composio connectors: **Slack, Jira, Notion, Confluence** (plus Stub/Nango)
- Distillation funnel: keyword prefilter → recall check → structured extract → rubric → gate → scope, carrying **verbatim evidence**
- Golden-set eval harness with a CI recall floor

### Core (`packages/core`)
- Migrations: `0002_ingestion`, `0003_fusion_graph`
- `/ingest` API routes; `graph-service`; decision **provenance, fusion & supersession** in the ledger

### Web (`packages/web`)
- Dashboard pages: **connections, review queue, search, graph, notifications**

### CLI
- Updated agent skill / templates

## Intentionally excluded
Pitch decks and website copy/plan docs are kept out of this public repo (marketing lives in its own repo, per `.gitignore`). Local `graphify-out/` analysis output is now git-ignored.

## Test plan
- [ ] `pnpm test` across packages (ingest funnel/eval, core ledger/ingest/graph, e2e)
- [ ] Manual: connect a Slack source → distill → review queue → lock → session briefing

🤖 Generated with [Claude Code](https://claude.com/claude-code)