### PR TITLE
infra: Dockerfile + Railway config for the ingest sweep worker

### DIFF
--- a/packages/ingest/Dockerfile
+++ b/packages/ingest/Dockerfile
@@ -1,0 +1,16 @@
+# Built from the monorepo root context. The v2 ingest sweep worker: no HTTP server,
+# it loops `sweep` on an interval and talks to core over LOCKSTEP_API_URL.
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY . .
+RUN npm install
+RUN npm run build -w @lockstep/ingest
+
+FROM node:20-alpine AS run
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/packages/ingest ./packages/ingest
+# Loop: fetch → distill → propose, every 15 min (serve default). Env: LOCKSTEP_API_URL,
+# LOCKSTEP_INGEST_TOKEN, COMPOSIO_API_KEY, ANTHROPIC_API_KEY.
+CMD ["node", "packages/ingest/dist/index.js", "serve"]

--- a/railway.ingest.json
+++ b/railway.ingest.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "packages/ingest/Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}


### PR DESCRIPTION
## What
Adds the **third deployable** — the v2 ingest sweep worker (`@lockstep/ingest`) — so Slack/Jira/Notion ingestion can actually run. Today only `lockstep` (core) and `lockstep-web` are deployed; the worker has never had deploy config.

- `packages/ingest/Dockerfile` — builds `@lockstep/ingest`, runs `serve` (loop sweep, 15-min default). No HTTP server; talks to core over `LOCKSTEP_API_URL`.
- `railway.ingest.json` — `DOCKERFILE` builder, `ON_FAILURE` restart, no healthcheck (worker, not a server).

## Deploy (after merge)
Create a new Railway service in the existing project, point it at this repo with **Config file = `railway.ingest.json`**, and set env vars:
- `ANTHROPIC_API_KEY`, `COMPOSIO_API_KEY`
- `LOCKSTEP_INGEST_TOKEN` (must match the value on the `lockstep` core service)
- `LOCKSTEP_API_URL` (public URL of the `lockstep` core service)

Also confirm `LOCKSTEP_INGEST_TOKEN` is set on the `lockstep` core service (same value).

## Notes
- Worker is standalone (no `@lockstep/core` dep; `@composio/core` + `@anthropic-ai/sdk` are declared deps).
- `npm run build -w @lockstep/ingest` passes. Docker image not built locally (no daemon in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)